### PR TITLE
Add enhanced receiving workflow with item creation

### DIFF
--- a/migrations/008_receiving_enhancements.sql
+++ b/migrations/008_receiving_enhancements.sql
@@ -1,0 +1,194 @@
+-- Migration: Enhanced Receiving Workflow
+-- Adds support for detailed receiving tracking, item creation, and automatic status updates
+
+-- Add receiving tracking fields to order_items
+ALTER TABLE order_items
+ADD COLUMN IF NOT EXISTS receiving_notes TEXT,
+ADD COLUMN IF NOT EXISTS received_by TEXT,
+ADD COLUMN IF NOT EXISTS last_received_at TIMESTAMPTZ;
+
+-- Create receiving history table to track all receiving actions
+CREATE TABLE IF NOT EXISTS receiving_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_item_id UUID NOT NULL REFERENCES order_items(id) ON DELETE CASCADE,
+    acquisition_order_id UUID NOT NULL REFERENCES acquisition_orders(id) ON DELETE CASCADE,
+    quantity_received INTEGER NOT NULL CHECK (quantity_received > 0),
+    received_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    received_by TEXT NOT NULL,
+    status VARCHAR(50) NOT NULL, -- 'received', 'backordered', 'cancelled'
+    notes TEXT,
+    items_created INTEGER DEFAULT 0, -- Number of item records created
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_receiving_history_order_item ON receiving_history(order_item_id);
+CREATE INDEX idx_receiving_history_order ON receiving_history(acquisition_order_id);
+CREATE INDEX idx_receiving_history_date ON receiving_history(received_date);
+
+-- Create claims table for tracking overdue orders
+CREATE TABLE IF NOT EXISTS claims (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    acquisition_order_id UUID NOT NULL REFERENCES acquisition_orders(id) ON DELETE CASCADE,
+    order_item_id UUID REFERENCES order_items(id) ON DELETE SET NULL,
+    claim_type VARCHAR(50) NOT NULL, -- 'overdue', 'missing', 'damaged'
+    claim_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    expected_delivery_date DATE,
+    days_overdue INTEGER,
+    claim_method VARCHAR(50), -- 'email', 'phone', 'letter'
+    claimed_by TEXT NOT NULL,
+    vendor_response TEXT,
+    response_date DATE,
+    resolution VARCHAR(50), -- 'received', 'refunded', 'cancelled', 'pending'
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_claims_order ON claims(acquisition_order_id);
+CREATE INDEX idx_claims_order_item ON claims(order_item_id);
+CREATE INDEX idx_claims_resolution ON claims(resolution);
+CREATE INDEX idx_claims_date ON claims(claim_date);
+
+-- Function to generate unique barcodes for items
+CREATE OR REPLACE FUNCTION generate_barcode()
+RETURNS TEXT AS $$
+DECLARE
+    new_barcode TEXT;
+    barcode_exists BOOLEAN;
+BEGIN
+    LOOP
+        -- Format: ILS-YYYYMMDD-XXXX (e.g., ILS-20250115-0001)
+        new_barcode := 'ILS-' ||
+                      TO_CHAR(CURRENT_DATE, 'YYYYMMDD') || '-' ||
+                      LPAD(FLOOR(RANDOM() * 10000)::TEXT, 4, '0');
+
+        -- Check if barcode already exists
+        SELECT EXISTS(SELECT 1 FROM items WHERE barcode = new_barcode) INTO barcode_exists;
+
+        -- If unique, return it
+        IF NOT barcode_exists THEN
+            RETURN new_barcode;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to auto-update order status based on item statuses
+CREATE OR REPLACE FUNCTION update_order_status_on_receive()
+RETURNS TRIGGER AS $$
+DECLARE
+    order_id UUID;
+    total_items INTEGER;
+    received_items INTEGER;
+    cancelled_items INTEGER;
+    backordered_items INTEGER;
+    new_status VARCHAR(50);
+BEGIN
+    -- Get the order ID
+    order_id := NEW.acquisition_order_id;
+
+    -- Count items by status
+    SELECT
+        COUNT(*) as total,
+        COUNT(*) FILTER (WHERE status = 'received') as received,
+        COUNT(*) FILTER (WHERE status = 'cancelled') as cancelled,
+        COUNT(*) FILTER (WHERE status = 'backordered') as backordered
+    INTO total_items, received_items, cancelled_items, backordered_items
+    FROM order_items
+    WHERE acquisition_order_id = order_id;
+
+    -- Determine new order status
+    IF received_items = total_items THEN
+        new_status := 'received';
+    ELSIF cancelled_items = total_items THEN
+        new_status := 'cancelled';
+    ELSIF received_items > 0 OR cancelled_items > 0 THEN
+        new_status := 'partial';
+    ELSE
+        new_status := 'ordered';
+    END IF;
+
+    -- Update order status
+    UPDATE acquisition_orders
+    SET status = new_status,
+        received_date = CASE
+            WHEN new_status = 'received' THEN CURRENT_DATE
+            ELSE received_date
+        END
+    WHERE id = order_id;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-update order status when items are received
+DROP TRIGGER IF EXISTS trigger_update_order_status ON order_items;
+CREATE TRIGGER trigger_update_order_status
+    AFTER UPDATE OF status, quantity_received ON order_items
+    FOR EACH ROW
+    WHEN (OLD.status IS DISTINCT FROM NEW.status OR OLD.quantity_received IS DISTINCT FROM NEW.quantity_received)
+    EXECUTE FUNCTION update_order_status_on_receive();
+
+-- Function to update claims updated_at timestamp
+CREATE OR REPLACE FUNCTION update_claims_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-update claims updated_at
+CREATE TRIGGER trigger_claims_updated_at
+    BEFORE UPDATE ON claims
+    FOR EACH ROW
+    EXECUTE FUNCTION update_claims_updated_at();
+
+-- Add invoice line items table for invoice matching
+CREATE TABLE IF NOT EXISTS invoice_line_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    invoice_id UUID NOT NULL REFERENCES invoices(id) ON DELETE CASCADE,
+    order_item_id UUID REFERENCES order_items(id) ON DELETE SET NULL,
+    description TEXT NOT NULL,
+    isbn VARCHAR(20),
+    quantity INTEGER NOT NULL CHECK (quantity > 0),
+    unit_price DECIMAL(10, 2) NOT NULL CHECK (unit_price >= 0),
+    discount_percent DECIMAL(5, 2) DEFAULT 0 CHECK (discount_percent >= 0 AND discount_percent <= 100),
+    line_total DECIMAL(10, 2) NOT NULL CHECK (line_total >= 0),
+    matched BOOLEAN DEFAULT FALSE,
+    discrepancy_type VARCHAR(50), -- 'price_difference', 'quantity_difference', 'not_ordered', 'duplicate', null if no discrepancy
+    discrepancy_notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_invoice_line_items_invoice ON invoice_line_items(invoice_id);
+CREATE INDEX idx_invoice_line_items_order_item ON invoice_line_items(order_item_id);
+CREATE INDEX idx_invoice_line_items_matched ON invoice_line_items(matched);
+
+-- Add approval fields to invoices table
+ALTER TABLE invoices
+ADD COLUMN IF NOT EXISTS approved_for_payment BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS approved_by TEXT,
+ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS payment_status VARCHAR(50) DEFAULT 'pending'; -- 'pending', 'approved', 'paid', 'disputed'
+
+-- Function to calculate invoice line total
+CREATE OR REPLACE FUNCTION calculate_invoice_line_total()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.line_total := (NEW.quantity * NEW.unit_price) * (1 - NEW.discount_percent / 100.0);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to auto-calculate invoice line totals
+CREATE TRIGGER trigger_calculate_invoice_line_total
+    BEFORE INSERT OR UPDATE OF quantity, unit_price, discount_percent ON invoice_line_items
+    FOR EACH ROW
+    EXECUTE FUNCTION calculate_invoice_line_total();
+
+COMMENT ON TABLE receiving_history IS 'Tracks all receiving actions for audit and history';
+COMMENT ON TABLE claims IS 'Tracks claims for overdue, missing, or damaged orders';
+COMMENT ON TABLE invoice_line_items IS 'Line items for invoices to enable order matching and discrepancy detection';
+COMMENT ON FUNCTION generate_barcode() IS 'Generates unique barcodes for physical items';
+COMMENT ON FUNCTION update_order_status_on_receive() IS 'Automatically updates order status based on item receiving status';

--- a/src/routes/admin/acquisitions/+page.svelte
+++ b/src/routes/admin/acquisitions/+page.svelte
@@ -158,6 +158,11 @@
 			<p>Create and manage orders, track receiving and payments</p>
 		</a>
 
+		<a href="/admin/acquisitions/receiving" class="module-card highlight">
+			<h3>Receiving</h3>
+			<p>Process incoming shipments, create item records, and track deliveries</p>
+		</a>
+
 		<a href="/admin/acquisitions/invoices" class="module-card">
 			<h3>Invoices & Payments</h3>
 			<p>Process invoices and record payments to vendors</p>
@@ -306,6 +311,15 @@
 		border-color: var(--accent);
 		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 		transform: translateY(-2px);
+	}
+
+	.module-card.highlight {
+		border-color: var(--accent);
+		background: linear-gradient(135deg, #ffffff 0%, #fef3f2 100%);
+	}
+
+	.module-card.highlight h3 {
+		font-weight: 700;
 	}
 
 	.module-card h3 {

--- a/src/routes/admin/acquisitions/receiving/+page.svelte
+++ b/src/routes/admin/acquisitions/receiving/+page.svelte
@@ -1,0 +1,999 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import { onMount } from 'svelte';
+
+	let { data }: { data: PageData } = $props();
+
+	let orders = $state<any[]>([]);
+	let items = $state<any[]>([]);
+	let loading = $state(true);
+	let message = $state('');
+	let filterStatus = $state('all');
+	let filterVendor = $state('all');
+	let showOverdueOnly = $state(false);
+	let vendors = $state<any[]>([]);
+
+	// Receiving modal state
+	let showReceivingModal = $state(false);
+	let receivingItem = $state<any>(null);
+	let receiveQuantity = $state(0);
+	let receiveStatus = $state<'received' | 'backordered' | 'cancelled'>('received');
+	let receiveNotes = $state('');
+	let createItems = $state(true);
+
+	const today = new Date().toISOString().split('T')[0];
+
+	onMount(async () => {
+		await Promise.all([loadOrders(), loadVendors()]);
+	});
+
+	async function loadOrders() {
+		loading = true;
+
+		const { data: ordersData } = await data.supabase
+			.from('acquisition_orders')
+			.select(
+				`
+				*,
+				vendor:vendors(id, name),
+				items:order_items(
+					*,
+					marc_record:marc_records(id, title_statement),
+					budget:budgets(name, code)
+				)
+			`
+			)
+			.in('status', ['ordered', 'partial'])
+			.order('expected_delivery_date', { ascending: true, nullsFirst: false });
+
+		if (ordersData) {
+			orders = ordersData;
+			// Flatten items for easier display
+			items = ordersData.flatMap((order) =>
+				(order.items || []).map((item: any) => ({
+					...item,
+					order_number: order.order_number,
+					order_id: order.id,
+					vendor_name: order.vendor?.name,
+					expected_delivery_date: order.expected_delivery_date
+				}))
+			);
+		}
+
+		loading = false;
+	}
+
+	async function loadVendors() {
+		const { data: vendorsData } = await data.supabase
+			.from('vendors')
+			.select('id, name')
+			.eq('is_active', true)
+			.order('name');
+
+		vendors = vendorsData || [];
+	}
+
+	const filteredItems = $derived(() => {
+		let filtered = items;
+
+		// Filter by status
+		if (filterStatus !== 'all') {
+			filtered = filtered.filter((item) => item.status === filterStatus);
+		}
+
+		// Filter by vendor
+		if (filterVendor !== 'all') {
+			filtered = filtered.filter((item) => {
+				const order = orders.find((o) => o.id === item.order_id);
+				return order?.vendor_id === filterVendor;
+			});
+		}
+
+		// Filter overdue
+		if (showOverdueOnly) {
+			filtered = filtered.filter((item) => {
+				if (!item.expected_delivery_date) return false;
+				return item.expected_delivery_date < today && item.status === 'ordered';
+			});
+		}
+
+		return filtered;
+	});
+
+	const stats = $derived({
+		total: items.length,
+		ordered: items.filter((i) => i.status === 'ordered').length,
+		backordered: items.filter((i) => i.status === 'backordered').length,
+		overdue: items.filter(
+			(i) =>
+				i.expected_delivery_date &&
+				i.expected_delivery_date < today &&
+				i.status === 'ordered'
+		).length
+	});
+
+	function openReceivingModal(item: any) {
+		receivingItem = item;
+		const remaining = item.quantity - (item.quantity_received || 0);
+		receiveQuantity = remaining;
+		receiveStatus = 'received';
+		receiveNotes = '';
+		createItems = true;
+		showReceivingModal = true;
+	}
+
+	function closeReceivingModal() {
+		showReceivingModal = false;
+		receivingItem = null;
+		receiveQuantity = 0;
+		receiveNotes = '';
+	}
+
+	async function processReceiving() {
+		if (!receivingItem || receiveQuantity <= 0) {
+			message = 'Error: Invalid quantity';
+			return;
+		}
+
+		const remaining = receivingItem.quantity - (receivingItem.quantity_received || 0);
+		if (receiveQuantity > remaining && receiveStatus === 'received') {
+			message = `Error: Cannot receive more than ${remaining} items`;
+			return;
+		}
+
+		try {
+			const newTotalReceived =
+				(receivingItem.quantity_received || 0) +
+				(receiveStatus === 'received' ? receiveQuantity : 0);
+			const finalStatus =
+				receiveStatus === 'received'
+					? newTotalReceived >= receivingItem.quantity
+						? 'received'
+						: 'ordered'
+					: receiveStatus;
+
+			// Update order item
+			const { error: updateError } = await data.supabase
+				.from('order_items')
+				.update({
+					quantity_received: newTotalReceived,
+					status: finalStatus,
+					received_date:
+						receiveStatus === 'received'
+							? new Date().toISOString().split('T')[0]
+							: receivingItem.received_date,
+					receiving_notes: receiveNotes || null,
+					received_by: data.session?.user?.email || 'Unknown',
+					last_received_at: new Date().toISOString()
+				})
+				.eq('id', receivingItem.id);
+
+			if (updateError) throw updateError;
+
+			// Create receiving history record
+			const { error: historyError } = await data.supabase.from('receiving_history').insert([
+				{
+					order_item_id: receivingItem.id,
+					acquisition_order_id: receivingItem.order_id,
+					quantity_received: receiveQuantity,
+					received_date: new Date().toISOString().split('T')[0],
+					received_by: data.session?.user?.email || 'Unknown',
+					status: receiveStatus,
+					notes: receiveNotes || null,
+					items_created: createItems && receiveStatus === 'received' ? receiveQuantity : 0
+				}
+			]);
+
+			if (historyError) throw historyError;
+
+			// Create physical item records if requested and status is 'received'
+			if (createItems && receiveStatus === 'received' && receiveQuantity > 0) {
+				const order = orders.find((o) => o.id === receivingItem.order_id);
+				const itemsToCreate = [];
+
+				for (let i = 0; i < receiveQuantity; i++) {
+					const { data: barcodeData, error: barcodeError } =
+						await data.supabase.rpc('generate_barcode');
+
+					if (barcodeError) {
+						console.error('Error generating barcode:', barcodeError);
+						continue;
+					}
+
+					itemsToCreate.push({
+						marc_record_id: receivingItem.marc_record_id || null,
+						barcode: barcodeData,
+						copy_number: (receivingItem.quantity_received || 0) + i + 1,
+						status: 'in_processing',
+						acquisition_date: new Date().toISOString().split('T')[0],
+						acquisition_source: 'purchase',
+						vendor_id: order?.vendor_id,
+						price: receivingItem.unit_price,
+						currency: 'USD'
+					});
+				}
+
+				if (itemsToCreate.length > 0) {
+					const { error: itemsError } = await data.supabase.from('items').insert(itemsToCreate);
+
+					if (itemsError) {
+						console.error('Error creating items:', itemsError);
+						message = `Warning: Items received but ${itemsToCreate.length} physical item records failed to create`;
+					}
+				}
+			}
+
+			await loadOrders();
+			closeReceivingModal();
+
+			const statusText =
+				receiveStatus === 'received'
+					? `Received ${receiveQuantity} item(s)`
+					: `Marked ${receiveQuantity} item(s) as ${receiveStatus}`;
+			const itemsText =
+				createItems && receiveStatus === 'received'
+					? ` and created ${receiveQuantity} item record(s)`
+					: '';
+			message = statusText + itemsText;
+
+			setTimeout(() => (message = ''), 5000);
+		} catch (err: any) {
+			message = `Error: ${err.message}`;
+		}
+	}
+
+	function isOverdue(item: any): boolean {
+		return (
+			!!item.expected_delivery_date &&
+			item.expected_delivery_date < today &&
+			item.status === 'ordered'
+		);
+	}
+</script>
+
+<div class="receiving-page">
+	<header class="page-header">
+		<div>
+			<h1>Receiving</h1>
+			<p class="subtitle">Process incoming orders and shipments</p>
+		</div>
+		<div class="header-actions">
+			<a href="/admin/acquisitions" class="btn-back">← Back to Acquisitions</a>
+		</div>
+	</header>
+
+	{#if message}
+		<div class={message.startsWith('Error') ? 'message error' : 'message success'}>
+			{message}
+		</div>
+	{/if}
+
+	<!-- Stats Cards -->
+	<div class="stats-grid">
+		<div class="stat-card">
+			<div class="stat-value">{stats.total}</div>
+			<div class="stat-label">Total Items Awaiting</div>
+		</div>
+		<div class="stat-card">
+			<div class="stat-value">{stats.ordered}</div>
+			<div class="stat-label">On Order</div>
+		</div>
+		<div class="stat-card">
+			<div class="stat-value">{stats.backordered}</div>
+			<div class="stat-label">Backordered</div>
+		</div>
+		<div class="stat-card alert">
+			<div class="stat-value">{stats.overdue}</div>
+			<div class="stat-label">Overdue</div>
+		</div>
+	</div>
+
+	<!-- Filters -->
+	<div class="filters">
+		<div class="filter-group">
+			<label for="filterStatus">Status:</label>
+			<select id="filterStatus" bind:value={filterStatus}>
+				<option value="all">All</option>
+				<option value="ordered">Ordered</option>
+				<option value="backordered">Backordered</option>
+			</select>
+		</div>
+
+		<div class="filter-group">
+			<label for="filterVendor">Vendor:</label>
+			<select id="filterVendor" bind:value={filterVendor}>
+				<option value="all">All Vendors</option>
+				{#each vendors as vendor}
+					<option value={vendor.id}>{vendor.name}</option>
+				{/each}
+			</select>
+		</div>
+
+		<div class="filter-group">
+			<label class="checkbox-filter">
+				<input type="checkbox" bind:checked={showOverdueOnly} />
+				<span>Show Overdue Only</span>
+			</label>
+		</div>
+	</div>
+
+	<!-- Items List -->
+	<div class="items-section">
+		{#if loading}
+			<p class="loading">Loading items...</p>
+		{:else if filteredItems.length === 0}
+			<div class="empty-state">
+				<p>No items to receive.</p>
+			</div>
+		{:else}
+			<div class="items-table-container">
+				<table class="items-table">
+					<thead>
+						<tr>
+							<th>Order #</th>
+							<th>Item</th>
+							<th>Vendor</th>
+							<th>Expected Date</th>
+							<th>Qty</th>
+							<th>Received</th>
+							<th>Status</th>
+							<th>Actions</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each filteredItems as item}
+							<tr class:overdue={isOverdue(item)}>
+								<td>
+									<a href="/admin/acquisitions/orders/{item.order_id}" class="order-link">
+										{item.order_number}
+									</a>
+								</td>
+								<td>
+									<div class="item-title">
+										{#if item.marc_record}
+											<a
+												href="/admin/cataloging/edit/{item.marc_record.id}"
+												class="catalog-link"
+											>
+												{item.title}
+											</a>
+										{:else}
+											{item.title}
+										{/if}
+									</div>
+									{#if item.author}
+										<div class="item-author">{item.author}</div>
+									{/if}
+									{#if item.isbn}
+										<div class="item-isbn">ISBN: {item.isbn}</div>
+									{/if}
+								</td>
+								<td>{item.vendor_name || 'N/A'}</td>
+								<td>
+									{#if item.expected_delivery_date}
+										<span class:overdue-date={isOverdue(item)}>
+											{new Date(item.expected_delivery_date).toLocaleDateString()}
+										</span>
+										{#if isOverdue(item)}
+											<div class="overdue-badge">OVERDUE</div>
+										{/if}
+									{:else}
+										<span class="text-muted">Not set</span>
+									{/if}
+								</td>
+								<td>{item.quantity}</td>
+								<td>{item.quantity_received || 0}</td>
+								<td>
+									<span class="item-status {item.status}">{item.status}</span>
+								</td>
+								<td>
+									{#if item.status !== 'received' && item.status !== 'cancelled'}
+										<button class="btn-receive" onclick={() => openReceivingModal(item)}>
+											Receive
+										</button>
+									{:else if item.status === 'received'}
+										<span class="received-mark">✓</span>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Receiving Modal -->
+	{#if showReceivingModal && receivingItem}
+		<div class="modal-overlay" onclick={closeReceivingModal}>
+			<div class="modal-content" onclick={(e) => e.stopPropagation()}>
+				<div class="modal-header">
+					<h2>Receive Item</h2>
+					<button class="modal-close" onclick={closeReceivingModal}>×</button>
+				</div>
+
+				<div class="modal-body">
+					<div class="receiving-item-info">
+						<h3>{receivingItem.title}</h3>
+						{#if receivingItem.author}
+							<p class="item-author">{receivingItem.author}</p>
+						{/if}
+						{#if receivingItem.isbn}
+							<p class="item-isbn">ISBN: {receivingItem.isbn}</p>
+						{/if}
+						<p class="order-info">
+							Order: <a href="/admin/acquisitions/orders/{receivingItem.order_id}"
+								>{receivingItem.order_number}</a
+							>
+						</p>
+						<div class="quantity-info">
+							<span><strong>Ordered:</strong> {receivingItem.quantity}</span>
+							<span><strong>Already Received:</strong> {receivingItem.quantity_received || 0}</span>
+							<span
+								><strong>Remaining:</strong>
+								{receivingItem.quantity - (receivingItem.quantity_received || 0)}</span
+							>
+						</div>
+					</div>
+
+					<form
+						onsubmit={(e) => {
+							e.preventDefault();
+							processReceiving();
+						}}
+					>
+						<div class="form-group">
+							<label for="receiveQuantity">Quantity to Process *</label>
+							<input
+								id="receiveQuantity"
+								type="number"
+								bind:value={receiveQuantity}
+								min="1"
+								max={receiveStatus === 'received'
+									? receivingItem.quantity - (receivingItem.quantity_received || 0)
+									: receivingItem.quantity}
+								required
+							/>
+							<small class="help-text">
+								{#if receiveStatus === 'received'}
+									Maximum: {receivingItem.quantity - (receivingItem.quantity_received || 0)} remaining
+								{:else}
+									Enter quantity to mark as {receiveStatus}
+								{/if}
+							</small>
+						</div>
+
+						<div class="form-group">
+							<label for="receiveStatus">Status *</label>
+							<select id="receiveStatus" bind:value={receiveStatus} required>
+								<option value="received">Received</option>
+								<option value="backordered">Backordered</option>
+								<option value="cancelled">Cancelled</option>
+							</select>
+						</div>
+
+						{#if receiveStatus === 'received'}
+							<div class="form-group">
+								<label class="checkbox-label">
+									<input type="checkbox" bind:checked={createItems} />
+									<span>Create {receiveQuantity} physical item record(s) with barcodes</span>
+								</label>
+								<small class="help-text"
+									>Items will be created with status "in-processing" and ready for cataloging</small
+								>
+							</div>
+						{/if}
+
+						<div class="form-group">
+							<label for="receiveNotes">Notes</label>
+							<textarea
+								id="receiveNotes"
+								bind:value={receiveNotes}
+								rows="3"
+								placeholder="Any issues, damages, or special notes..."
+							></textarea>
+						</div>
+
+						<div class="modal-actions">
+							<button type="submit" class="btn-primary">
+								{receiveStatus === 'received' ? 'Receive Items' : `Mark as ${receiveStatus}`}
+							</button>
+							<button type="button" class="btn-secondary" onclick={closeReceivingModal}>
+								Cancel
+							</button>
+						</div>
+					</form>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.receiving-page {
+		max-width: 1600px;
+	}
+
+	.page-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		margin-bottom: 2rem;
+	}
+
+	h1 {
+		margin: 0 0 0.5rem 0;
+	}
+
+	.subtitle {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+
+	.header-actions {
+		display: flex;
+		gap: 1rem;
+	}
+
+	.btn-back {
+		padding: 0.75rem 1.5rem;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		text-decoration: none;
+		border-radius: var(--radius-sm);
+	}
+
+	.message {
+		padding: 1rem;
+		border-radius: var(--radius-sm);
+		margin-bottom: 1.5rem;
+	}
+
+	.message.success {
+		background: #d4edda;
+		color: #155724;
+		border: 1px solid #c3e6cb;
+	}
+
+	.message.error {
+		background: #f8d7da;
+		color: #721c24;
+		border: 1px solid #f5c6cb;
+	}
+
+	/* Stats Grid */
+	.stats-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 1.5rem;
+		margin-bottom: 2rem;
+	}
+
+	.stat-card {
+		background: white;
+		padding: 1.5rem;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border);
+	}
+
+	.stat-card.alert {
+		border-color: #ef4444;
+		background: #fef2f2;
+	}
+
+	.stat-value {
+		font-size: 2.5rem;
+		font-weight: 700;
+		color: var(--accent);
+		line-height: 1;
+		margin-bottom: 0.5rem;
+	}
+
+	.stat-card.alert .stat-value {
+		color: #ef4444;
+	}
+
+	.stat-label {
+		color: var(--text-muted);
+		font-size: 0.875rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	/* Filters */
+	.filters {
+		display: flex;
+		gap: 1.5rem;
+		align-items: flex-end;
+		margin-bottom: 1.5rem;
+		padding: 1.5rem;
+		background: white;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border);
+	}
+
+	.filter-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.filter-group label {
+		font-weight: 600;
+		font-size: 0.875rem;
+		color: var(--text-primary);
+	}
+
+	.filter-group select {
+		padding: 0.75rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		font-size: 1rem;
+		min-width: 200px;
+	}
+
+	.checkbox-filter {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		cursor: pointer;
+		padding-top: 0.5rem;
+	}
+
+	.checkbox-filter input[type='checkbox'] {
+		width: 1.25rem;
+		height: 1.25rem;
+		cursor: pointer;
+	}
+
+	/* Items Section */
+	.items-section {
+		background: white;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--border);
+	}
+
+	.loading,
+	.empty-state {
+		text-align: center;
+		padding: 3rem;
+		color: var(--text-muted);
+	}
+
+	.items-table-container {
+		overflow-x: auto;
+	}
+
+	.items-table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+
+	.items-table thead {
+		background: var(--bg-secondary);
+	}
+
+	.items-table th {
+		padding: 1rem;
+		text-align: left;
+		font-weight: 600;
+		font-size: 0.875rem;
+		color: var(--text-muted);
+		text-transform: uppercase;
+	}
+
+	.items-table td {
+		padding: 1rem;
+		border-top: 1px solid var(--border);
+		font-size: 0.875rem;
+	}
+
+	.items-table tr.overdue {
+		background: #fef2f2;
+	}
+
+	.order-link,
+	.catalog-link {
+		color: var(--accent);
+		text-decoration: none;
+		font-weight: 600;
+	}
+
+	.order-link:hover,
+	.catalog-link:hover {
+		text-decoration: underline;
+	}
+
+	.item-title {
+		font-weight: 600;
+		margin-bottom: 0.25rem;
+	}
+
+	.item-author,
+	.item-isbn {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+	}
+
+	.text-muted {
+		color: var(--text-muted);
+	}
+
+	.overdue-date {
+		color: #dc2626;
+		font-weight: 600;
+	}
+
+	.overdue-badge {
+		display: inline-block;
+		margin-top: 0.25rem;
+		padding: 0.125rem 0.5rem;
+		background: #dc2626;
+		color: white;
+		font-size: 0.625rem;
+		font-weight: 700;
+		border-radius: var(--radius-sm);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.item-status {
+		padding: 0.25rem 0.5rem;
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 600;
+		text-transform: uppercase;
+	}
+
+	.item-status.ordered {
+		background: #cce5ff;
+		color: #004085;
+	}
+
+	.item-status.backordered {
+		background: #fff7ed;
+		color: #c2410c;
+	}
+
+	.item-status.received {
+		background: #d4edda;
+		color: #155724;
+	}
+
+	.btn-receive {
+		padding: 0.5rem 1rem;
+		background: var(--accent);
+		color: white;
+		border: none;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 600;
+	}
+
+	.btn-receive:hover {
+		opacity: 0.9;
+	}
+
+	.received-mark {
+		color: #10b981;
+		font-size: 1.25rem;
+		font-weight: 600;
+	}
+
+	/* Modal Styles */
+	.modal-overlay {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+		padding: 1rem;
+	}
+
+	.modal-content {
+		background: white;
+		border-radius: var(--radius-md);
+		max-width: 600px;
+		width: 100%;
+		max-height: 90vh;
+		overflow-y: auto;
+		box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+	}
+
+	.modal-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 1.5rem;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.5rem;
+	}
+
+	.modal-close {
+		background: none;
+		border: none;
+		font-size: 2rem;
+		cursor: pointer;
+		color: var(--text-muted);
+		line-height: 1;
+		padding: 0;
+		width: 2rem;
+		height: 2rem;
+	}
+
+	.modal-close:hover {
+		color: var(--text-primary);
+	}
+
+	.modal-body {
+		padding: 1.5rem;
+	}
+
+	.receiving-item-info {
+		background: var(--bg-secondary);
+		padding: 1rem;
+		border-radius: var(--radius-sm);
+		margin-bottom: 1.5rem;
+	}
+
+	.receiving-item-info h3 {
+		margin: 0 0 0.5rem 0;
+		font-size: 1.125rem;
+	}
+
+	.receiving-item-info p {
+		margin: 0.25rem 0;
+		color: var(--text-muted);
+		font-size: 0.875rem;
+	}
+
+	.order-info a {
+		color: var(--accent);
+		text-decoration: none;
+	}
+
+	.order-info a:hover {
+		text-decoration: underline;
+	}
+
+	.quantity-info {
+		display: flex;
+		gap: 1.5rem;
+		margin-top: 1rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--border);
+		font-size: 0.875rem;
+	}
+
+	.form-group {
+		margin-bottom: 1.5rem;
+	}
+
+	.form-group label {
+		display: block;
+		margin-bottom: 0.5rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.form-group input[type='number'],
+	.form-group select,
+	.form-group textarea {
+		width: 100%;
+		padding: 0.75rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		font-size: 1rem;
+		font-family: inherit;
+	}
+
+	.form-group input:focus,
+	.form-group select:focus,
+	.form-group textarea:focus {
+		outline: none;
+		border-color: var(--accent);
+	}
+
+	.form-group textarea {
+		resize: vertical;
+	}
+
+	.help-text {
+		display: block;
+		margin-top: 0.5rem;
+		font-size: 0.875rem;
+		color: var(--text-muted);
+	}
+
+	.checkbox-label {
+		display: flex;
+		align-items: flex-start;
+		gap: 0.75rem;
+		cursor: pointer;
+		font-weight: normal;
+	}
+
+	.checkbox-label input[type='checkbox'] {
+		margin-top: 0.25rem;
+		width: 1.25rem;
+		height: 1.25rem;
+		cursor: pointer;
+	}
+
+	.modal-actions {
+		display: flex;
+		gap: 1rem;
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border);
+	}
+
+	.btn-primary {
+		padding: 0.75rem 1.5rem;
+		background: var(--accent);
+		color: white;
+		border: none;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		font-size: 1rem;
+		font-weight: 600;
+	}
+
+	.btn-primary:hover {
+		opacity: 0.9;
+	}
+
+	.btn-secondary {
+		padding: 0.75rem 1.5rem;
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		font-size: 1rem;
+	}
+
+	.btn-secondary:hover {
+		background: var(--border);
+	}
+
+	@media (max-width: 768px) {
+		.stats-grid {
+			grid-template-columns: repeat(2, 1fr);
+		}
+
+		.filters {
+			flex-direction: column;
+			align-items: stretch;
+		}
+
+		.filter-group select {
+			min-width: unset;
+		}
+
+		.items-table {
+			font-size: 0.75rem;
+		}
+
+		.items-table th,
+		.items-table td {
+			padding: 0.5rem;
+		}
+
+		.quantity-info {
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+	}
+</style>


### PR DESCRIPTION
Phase 1 Implementation:

Database:
- Add receiving_history table to track all receiving actions
- Add claims table for overdue order tracking
- Add invoice_line_items table for invoice matching
- Add receiving_notes, received_by, last_received_at to order_items
- Create generate_barcode() function for unique item barcodes
- Auto-update order status based on item statuses

Features:
- Enhanced receiving modal on order detail page with:
  * Custom quantity input for partial receives
  * Status dropdown (received/backordered/cancelled)
  * Notes field for receiving issues
  * Automatic item creation with barcode generation
  * Receiving history tracking
- Dedicated /admin/acquisitions/receiving page with:
  * List all orders with 'ordered' or 'partial' status
  * Filter by status, vendor, and overdue items
  * Stats dashboard (total, ordered, backordered, overdue)
  * Quick receiving workflow
  * Overdue order highlighting
- Add receiving link to acquisitions dashboard

Items created on receive get:
- Unique barcode (ILS-YYYYMMDD-XXXX format)
- Status: "in_processing" (ready for cataloging)
- Acquisition metadata (date, vendor, price)
- Proper copy numbering