### PR TITLE
Fix build errors and clickable links

### DIFF
--- a/src/lib/components/AccessibilitySettings.svelte
+++ b/src/lib/components/AccessibilitySettings.svelte
@@ -152,7 +152,7 @@
 					<button
 						class="size-button"
 						class:active={fontSize === 'large'}
-						onclick={() => setFontSize('large'}
+						onclick={() => setFontSize('large')}
 						role="radio"
 						aria-checked={fontSize === 'large'}
 					>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,4 @@
-import { createBrowserClient, createServerClient, isBrowser } from '@supabase/ssr';
+import { createBrowserClient } from '@supabase/ssr';
 import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
-import type { LayoutLoad } from './$types';
 
 export const supabase = createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 
 	// Get branding configuration with defaults
 	const branding = $derived(
-		data.branding || {
+		(data as any).branding || {
 			library_name: 'Library Catalog System',
 			primary_color: '#e73b42',
 			secondary_color: '#667eea',

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -19,9 +19,9 @@
 </svelte:head>
 
 {#if page}
-	<div class="page-container" class:layout-{page.layout}>
+	<div class="page-container layout-{page.layout || 'default'}">
 		<article class="page-content">
-			<h1 class="page-title">{page.title}</h1>
+			<h1 class="page-title">{page?.title || ''}</h1>
 
 			{#if page.excerpt}
 				<p class="page-excerpt">{page.excerpt}</p>
@@ -37,7 +37,7 @@
 		<h1>Page Not Found</h1>
 		<p>The requested page could not be found.</p>
 		<a href="/">← Back to Home</a>
-	</div}
+	</div>
 {/if}
 
 <style>

--- a/src/routes/admin/branding/+page.svelte
+++ b/src/routes/admin/branding/+page.svelte
@@ -326,7 +326,7 @@
 						<textarea
 							id="custom_css"
 							bind:value={branding.custom_css}
-							placeholder=".my-class { color: red; }"
+							placeholder="Enter custom CSS styles here"
 							rows="6"
 							style="font-family: monospace;"
 						></textarea>

--- a/src/routes/catalog/my-lists/[id]/+page.server.ts
+++ b/src/routes/catalog/my-lists/[id]/+page.server.ts
@@ -1,31 +1,56 @@
 import type { PageServerLoad } from './$types';
 import { error } from '@sveltejs/kit';
 
-export const load: PageServerLoad = async ({ params, locals, url }) => {
+export const load: PageServerLoad = async ({ params, locals }) => {
 	const supabase = locals.supabase;
 	const listId = params.id;
+	const session = await supabase.auth.getSession();
 
-	// Get list with items
-	const response = await fetch(`${url.origin}/api/reading-lists/${listId}`, {
-		headers: {
-			cookie: locals.cookies || ''
-		}
-	});
+	// Check if list is public or user is the owner
+	const { data: list, error: listError } = await supabase
+		.from('reading_lists')
+		.select('*')
+		.eq('id', listId)
+		.single();
 
-	if (!response.ok) {
-		if (response.status === 404) {
-			throw error(404, 'List not found');
-		}
-		if (response.status === 403) {
-			throw error(403, 'You do not have permission to view this list');
-		}
-		throw error(500, 'Failed to load list');
+	if (listError || !list) {
+		throw error(404, 'List not found');
 	}
 
-	const data = await response.json();
+	// If list is private, check ownership
+	if (!list.is_public) {
+		if (!session.data.session || session.data.session.user.id !== list.patron_id) {
+			throw error(403, 'You do not have permission to view this list');
+		}
+	}
+
+	// Get list items with MARC record details
+	const { data: items, error: itemsError } = await supabase
+		.from('reading_list_items')
+		.select(
+			`
+			*,
+			marc_records (
+				id,
+				title_statement,
+				main_entry_personal_name,
+				publication_info,
+				isbn,
+				material_type,
+				summary
+			)
+		`
+		)
+		.eq('list_id', listId)
+		.order('sort_order', { ascending: true });
+
+	if (itemsError) {
+		console.error('Error fetching list items:', itemsError);
+		throw error(500, 'Failed to load list items');
+	}
 
 	return {
-		list: data.list,
-		items: data.items || []
+		list,
+		items: items || []
 	};
 };

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -9,6 +9,10 @@
 
 	let { data }: { data: PageData } = $props();
 
+	// Pagination defaults
+	const currentPage = $derived(data.page || 1);
+	const currentPerPage = $derived(data.per_page || 20);
+
 	let showFilters = $state(true);
 	let mobileFiltersOpen = $state(false);
 	let shareMenuOpen = $state(false);
@@ -427,9 +431,9 @@
 	}
 
 	// Calculate pagination
-	const totalPages = $derived(Math.ceil(data.total / data.per_page));
-	const startResult = $derived((data.page - 1) * data.per_page + 1);
-	const endResult = $derived(Math.min(data.page * data.per_page, data.total));
+	const totalPages = $derived(Math.ceil(data.total / currentPerPage));
+	const startResult = $derived((currentPage - 1) * currentPerPage + 1);
+	const endResult = $derived(Math.min(currentPage * currentPerPage, data.total));
 </script>
 
 <div class="search-results-page">
@@ -464,7 +468,7 @@
 						<p class="results-count">
 							{data.total.toLocaleString()} result{data.total === 1 ? '' : 's'}
 							{#if totalPages > 1}
-								· Page {data.page} of {totalPages}
+								· Page {currentPage} of {totalPages}
 							{/if}
 						</p>
 					{/if}
@@ -783,8 +787,8 @@
 										{/if}
 									</p>
 								{/if}
-								{#if record.items && record.items.some((item) => item.is_electronic && item.url)}
-									{@const electronicItem = record.items.find((item) => item.is_electronic && item.url)}
+								{#if record.items && record.items.some((item: any) => item.is_electronic && item.url)}
+									{@const electronicItem = record.items.find((item: any) => item.is_electronic && item.url)}
 									<p class="electronic-access">
 										<svg
 											width="16"
@@ -824,7 +828,7 @@
 										<span class="badge lang">{record.language_code}</span>
 									{/if}
 									{#if record.items && record.items.length > 0}
-										{@const availableItems = record.items.filter((item) => item.status === 'available')}
+										{@const availableItems = record.items.filter((item: any) => item.status === 'available')}
 										{#if availableItems.length > 0}
 											<span class="badge available"
 												>{availableItems.length} available</span
@@ -844,8 +848,8 @@
 					<nav class="pagination" aria-label="Search results pagination">
 						<button
 							class="page-btn"
-							disabled={data.page === 1}
-							onclick={() => changePage(data.page - 1)}
+							disabled={currentPage === 1}
+							onclick={() => changePage(currentPage - 1)}
 						>
 							← Previous
 						</button>
@@ -853,13 +857,13 @@
 						<div class="page-numbers">
 							{#each Array.from({ length: Math.min(7, totalPages) }, (_, i) => {
 								if (totalPages <= 7) return i + 1;
-								if (data.page <= 4) return i + 1;
-								if (data.page >= totalPages - 3) return totalPages - 6 + i;
-								return data.page - 3 + i;
+								if (currentPage <= 4) return i + 1;
+								if (currentPage >= totalPages - 3) return totalPages - 6 + i;
+								return currentPage - 3 + i;
 							}) as pageNum}
 								<button
 									class="page-btn"
-									class:active={pageNum === data.page}
+									class:active={pageNum === currentPage}
 									onclick={() => changePage(pageNum)}
 								>
 									{pageNum}
@@ -869,8 +873,8 @@
 
 						<button
 							class="page-btn"
-							disabled={data.page === totalPages}
-							onclick={() => changePage(data.page + 1)}
+							disabled={currentPage === totalPages}
+							onclick={() => changePage(currentPage + 1)}
 						>
 							Next →
 						</button>


### PR DESCRIPTION
- Fix syntax errors in AccessibilitySettings (missing closing paren)
- Fix syntax errors in [slug] page (incorrect div closing tag and class directive)
- Fix branding page placeholder with curly braces causing parse errors
- Fix type errors in my-lists page (removed invalid locals.cookies reference)
- Fix layout branding type error with type assertion
- Fix search results pagination type errors with default values
- Remove invalid import from lib/supabase.ts
- Add type annotations for item parameters in search results

All builds now succeed. Clickable subjects, clickable authors, and LoC subject validation were already implemented correctly but weren't deployed due to build failures. This commit enables those features to work on the live site once deployed.