### PR TITLE
Add custom cover image upload and management

### DIFF
--- a/migrations/018_custom_cover_images.sql
+++ b/migrations/018_custom_cover_images.sql
@@ -1,0 +1,58 @@
+-- Migration: Custom Cover Image Upload
+-- Adds ability to upload and manage custom cover images for catalog records
+-- Created: 2025-12-30
+
+-- Add cover_image_url field to marc_records table
+ALTER TABLE marc_records
+ADD COLUMN IF NOT EXISTS cover_image_url TEXT;
+
+-- Add comment
+COMMENT ON COLUMN marc_records.cover_image_url IS 'URL to custom uploaded cover image. Takes priority over API-fetched covers.';
+
+-- Create index for faster queries
+CREATE INDEX IF NOT EXISTS idx_marc_records_cover_url ON marc_records(cover_image_url) WHERE cover_image_url IS NOT NULL;
+
+-- Create storage bucket for cover images (run this in Supabase Dashboard > Storage)
+-- This is informational - you'll need to create this bucket manually in Supabase
+/*
+MANUAL SETUP REQUIRED IN SUPABASE DASHBOARD:
+
+1. Go to Storage > Create Bucket
+2. Name: "cover-images"
+3. Public bucket: YES (so covers can be displayed)
+4. File size limit: 5MB
+5. Allowed MIME types: image/jpeg, image/png, image/webp, image/gif
+
+Or run this SQL in Supabase SQL Editor:
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'cover-images',
+  'cover-images',
+  true,
+  5242880, -- 5MB
+  ARRAY['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Set up storage policies
+CREATE POLICY "Public can view cover images"
+ON storage.objects FOR SELECT
+TO public
+USING (bucket_id = 'cover-images');
+
+CREATE POLICY "Authenticated users can upload covers"
+ON storage.objects FOR INSERT
+TO authenticated
+WITH CHECK (bucket_id = 'cover-images');
+
+CREATE POLICY "Authenticated users can update covers"
+ON storage.objects FOR UPDATE
+TO authenticated
+USING (bucket_id = 'cover-images');
+
+CREATE POLICY "Authenticated users can delete covers"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (bucket_id = 'cover-images');
+*/

--- a/src/lib/components/BookCover.svelte
+++ b/src/lib/components/BookCover.svelte
@@ -3,6 +3,7 @@
 		isbn?: string;
 		title?: string;
 		author?: string;
+		customCoverUrl?: string | null;
 		size?: 'small' | 'medium' | 'large';
 		showPlaceholder?: boolean;
 	}
@@ -11,6 +12,7 @@
 		isbn,
 		title,
 		author,
+		customCoverUrl,
 		size = 'medium',
 		showPlaceholder = true
 	}: Props = $props();
@@ -29,8 +31,15 @@
 	});
 
 	// Fetch cover when component mounts or props change
+	// Priority: customCoverUrl > API fetch
 	$effect(() => {
-		if (showCovers && (isbn || title)) {
+		if (customCoverUrl) {
+			// Use custom cover if provided
+			coverUrl = customCoverUrl;
+			loading = false;
+			error = false;
+		} else if (showCovers && (isbn || title)) {
+			// Fall back to API fetch
 			fetchCover();
 		}
 	});

--- a/src/routes/api/cover-upload/+server.ts
+++ b/src/routes/api/cover-upload/+server.ts
@@ -1,0 +1,143 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const { supabase, safeGetSession } = locals;
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	try {
+		const formData = await request.formData();
+		const file = formData.get('file') as File;
+		const recordId = formData.get('recordId') as string;
+
+		if (!file) {
+			return json({ error: 'No file provided' }, { status: 400 });
+		}
+
+		if (!recordId) {
+			return json({ error: 'No record ID provided' }, { status: 400 });
+		}
+
+		// Validate file type
+		const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+		if (!allowedTypes.includes(file.type)) {
+			return json({ error: 'Invalid file type. Only JPEG, PNG, WebP, and GIF are allowed.' }, { status: 400 });
+		}
+
+		// Validate file size (5MB max)
+		const maxSize = 5 * 1024 * 1024; // 5MB
+		if (file.size > maxSize) {
+			return json({ error: 'File too large. Maximum size is 5MB.' }, { status: 400 });
+		}
+
+		// Generate unique filename
+		const fileExt = file.name.split('.').pop();
+		const fileName = `${recordId}-${Date.now()}.${fileExt}`;
+		const filePath = `covers/${fileName}`;
+
+		// Convert File to ArrayBuffer
+		const arrayBuffer = await file.arrayBuffer();
+		const fileBuffer = new Uint8Array(arrayBuffer);
+
+		// Upload to Supabase Storage
+		const { data: uploadData, error: uploadError } = await supabase.storage
+			.from('cover-images')
+			.upload(filePath, fileBuffer, {
+				contentType: file.type,
+				upsert: false
+			});
+
+		if (uploadError) {
+			console.error('Upload error:', uploadError);
+			return json({ error: `Upload failed: ${uploadError.message}` }, { status: 500 });
+		}
+
+		// Get public URL
+		const { data: urlData } = supabase.storage
+			.from('cover-images')
+			.getPublicUrl(filePath);
+
+		const publicUrl = urlData.publicUrl;
+
+		// Update marc_records with cover URL
+		const { error: updateError } = await supabase
+			.from('marc_records')
+			.update({ cover_image_url: publicUrl })
+			.eq('id', recordId);
+
+		if (updateError) {
+			console.error('Database update error:', updateError);
+			// Try to delete the uploaded file if database update fails
+			await supabase.storage.from('cover-images').remove([filePath]);
+			return json({ error: 'Failed to update record' }, { status: 500 });
+		}
+
+		return json({
+			success: true,
+			coverUrl: publicUrl,
+			message: 'Cover uploaded successfully'
+		});
+
+	} catch (error) {
+		console.error('Cover upload error:', error);
+		return json({ error: 'Internal server error' }, { status: 500 });
+	}
+};
+
+export const DELETE: RequestHandler = async ({ request, locals }) => {
+	const { supabase, safeGetSession } = locals;
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	try {
+		const { recordId } = await request.json();
+
+		if (!recordId) {
+			return json({ error: 'No record ID provided' }, { status: 400 });
+		}
+
+		// Get current cover URL to extract filename
+		const { data: record } = await supabase
+			.from('marc_records')
+			.select('cover_image_url')
+			.eq('id', recordId)
+			.single();
+
+		if (record?.cover_image_url) {
+			// Extract filename from URL
+			const url = new URL(record.cover_image_url);
+			const pathParts = url.pathname.split('/');
+			const fileName = pathParts[pathParts.length - 1];
+			const filePath = `covers/${fileName}`;
+
+			// Delete from storage
+			await supabase.storage.from('cover-images').remove([filePath]);
+		}
+
+		// Remove cover URL from database
+		const { error: updateError } = await supabase
+			.from('marc_records')
+			.update({ cover_image_url: null })
+			.eq('id', recordId);
+
+		if (updateError) {
+			return json({ error: 'Failed to remove cover from record' }, { status: 500 });
+		}
+
+		return json({
+			success: true,
+			message: 'Cover removed successfully'
+		});
+
+	} catch (error) {
+		console.error('Cover delete error:', error);
+		return json({ error: 'Internal server error' }, { status: 500 });
+	}
+};


### PR DESCRIPTION
Features:
- Add cover_image_url field to marc_records table
- Create Supabase storage bucket for cover images (cover-images)
- Add /api/cover-upload endpoint for uploading and deleting covers
- Update BookCover component to prioritize custom covers over API-fetched
- Add cover upload UI to cataloging edit page with live preview
- Support JPEG, PNG, WebP, and GIF formats (max 5MB)
- Allow deleting custom covers to fall back to auto-fetched covers

Migration: migrations/018_custom_cover_images.sql
- Adds cover_image_url column to marc_records
- Includes setup instructions for Supabase storage bucket and RLS policies

UI Features:
- Live cover preview in edit form
- Drag-and-drop file upload button
- Upload status messages
- Remove custom cover button
- File validation (type and size)
- Helper text showing cover source (custom vs auto-fetched)

Custom covers take priority: custom upload > Google Books > Open Library