### PR TITLE
Add bulk cover fetch utility for existing records

### DIFF
--- a/src/routes/admin/cataloging/+page.svelte
+++ b/src/routes/admin/cataloging/+page.svelte
@@ -299,6 +299,7 @@
 			<a href="/admin/cataloging/templates" class="btn-secondary">Templates</a>
 			<a href="/admin/cataloging/marc-import" class="btn-secondary">MARC Import</a>
 			<a href="/admin/cataloging/marc-export" class="btn-secondary">MARC Export</a>
+			<a href="/admin/cataloging/fetch-covers" class="btn-secondary">📷 Fetch Covers</a>
 			{#if duplicates.size > 0}
 				<a href="/admin/cataloging/duplicates" class="btn-duplicates">
 					Manage Duplicates ({duplicates.size})

--- a/src/routes/admin/cataloging/fetch-covers/+page.svelte
+++ b/src/routes/admin/cataloging/fetch-covers/+page.svelte
@@ -1,0 +1,469 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	let totalRecords = $state(0);
+	let processedRecords = $state(0);
+	let foundCovers = $state(0);
+	let remainingRecords = $state(0);
+	let isRunning = $state(false);
+	let isPaused = $state(false);
+	let message = $state('');
+	let logs = $state<string[]>([]);
+	let batchSize = $state(10);
+
+	onMount(async () => {
+		await loadStats();
+	});
+
+	async function loadStats() {
+		try {
+			const { data: records, count } = await data.supabase
+				.from('marc_records')
+				.select('id', { count: 'exact', head: true })
+				.is('cover_image_url', null);
+
+			remainingRecords = count || 0;
+			totalRecords = count || 0;
+		} catch (error: any) {
+			message = `Error loading stats: ${error.message}`;
+		}
+	}
+
+	async function startFetching() {
+		isRunning = true;
+		isPaused = false;
+		processedRecords = 0;
+		foundCovers = 0;
+		logs = [];
+		message = 'Starting cover fetch...';
+
+		addLog(`Starting batch process with batch size: ${batchSize}`);
+
+		while (remainingRecords > 0 && !isPaused) {
+			try {
+				const response = await fetch('/api/fetch-covers', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ batchSize })
+				});
+
+				const result = await response.json();
+
+				if (!response.ok) {
+					throw new Error(result.error || 'Fetch failed');
+				}
+
+				processedRecords += result.processed;
+				foundCovers += result.found;
+				remainingRecords = result.remaining;
+
+				addLog(
+					`Batch complete: Processed ${result.processed}, Found ${result.found}, Remaining ${result.remaining}`
+				);
+
+				// Log individual results
+				result.results?.forEach((r: any) => {
+					if (r.success && r.coverUrl) {
+						addLog(`✓ Found cover for: ${r.title}`);
+					} else if (!r.coverUrl) {
+						addLog(`✗ No cover found for: ${r.title}`);
+					}
+				});
+
+				if (result.remaining === 0) {
+					message = `Complete! Processed ${processedRecords} records, found ${foundCovers} covers.`;
+					addLog('All records processed!');
+					isRunning = false;
+					break;
+				}
+
+				// Small delay between batches to avoid rate limiting
+				await new Promise((resolve) => setTimeout(resolve, 1000));
+			} catch (error: any) {
+				message = `Error: ${error.message}`;
+				addLog(`Error: ${error.message}`);
+				isRunning = false;
+				break;
+			}
+		}
+
+		if (isPaused) {
+			message = 'Paused. Click Resume to continue.';
+			addLog('Process paused by user');
+			isRunning = false;
+		}
+	}
+
+	function pauseResume() {
+		if (isRunning) {
+			isPaused = true;
+		} else {
+			startFetching();
+		}
+	}
+
+	function reset() {
+		isRunning = false;
+		isPaused = false;
+		processedRecords = 0;
+		foundCovers = 0;
+		logs = [];
+		message = '';
+		loadStats();
+	}
+
+	function addLog(logMessage: string) {
+		const timestamp = new Date().toLocaleTimeString();
+		logs = [`[${timestamp}] ${logMessage}`, ...logs];
+		if (logs.length > 100) {
+			logs = logs.slice(0, 100);
+		}
+	}
+</script>
+
+<div class="fetch-covers-page">
+	<div class="header">
+		<h1>Fetch Book Covers</h1>
+		<p>
+			Automatically fetch and save cover images for all catalog records from Google Books and Open
+			Library APIs.
+		</p>
+	</div>
+
+	<!-- Stats -->
+	<div class="stats-grid">
+		<div class="stat-card">
+			<div class="stat-value">{totalRecords}</div>
+			<div class="stat-label">Total Records Without Covers</div>
+		</div>
+		<div class="stat-card">
+			<div class="stat-value">{processedRecords}</div>
+			<div class="stat-label">Processed This Session</div>
+		</div>
+		<div class="stat-card">
+			<div class="stat-value">{foundCovers}</div>
+			<div class="stat-label">Covers Found</div>
+		</div>
+		<div class="stat-card">
+			<div class="stat-value">{remainingRecords}</div>
+			<div class="stat-label">Remaining</div>
+		</div>
+	</div>
+
+	{#if message}
+		<div class="message">{message}</div>
+	{/if}
+
+	<!-- Progress Bar -->
+	{#if totalRecords > 0}
+		<div class="progress-section">
+			<div class="progress-label">
+				Progress: {processedRecords} / {totalRecords} ({Math.round((processedRecords / totalRecords) * 100)}%)
+			</div>
+			<div class="progress-bar">
+				<div
+					class="progress-fill"
+					style="width: {(processedRecords / totalRecords) * 100}%"
+				></div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Controls -->
+	<div class="controls">
+		<div class="batch-size-control">
+			<label for="batchSize">Batch Size:</label>
+			<input
+				id="batchSize"
+				type="number"
+				bind:value={batchSize}
+				min="1"
+				max="50"
+				disabled={isRunning}
+			/>
+			<small>Records to process per batch (1-50)</small>
+		</div>
+
+		<div class="button-group">
+			{#if !isRunning && processedRecords === 0}
+				<button class="btn-primary" onclick={startFetching} disabled={remainingRecords === 0}>
+					Start Fetching Covers
+				</button>
+			{:else if isRunning}
+				<button class="btn-warning" onclick={pauseResume}>Pause</button>
+			{:else if isPaused || processedRecords > 0}
+				<button class="btn-primary" onclick={pauseResume}>
+					{isPaused ? 'Resume' : 'Continue'}
+				</button>
+				<button class="btn-secondary" onclick={reset}>Reset</button>
+			{/if}
+
+			<button class="btn-secondary" onclick={loadStats}>Refresh Stats</button>
+		</div>
+	</div>
+
+	<!-- Log -->
+	<div class="log-section">
+		<h2>Activity Log</h2>
+		<div class="log-container">
+			{#if logs.length === 0}
+				<div class="log-empty">No activity yet. Click "Start Fetching Covers" to begin.</div>
+			{:else}
+				{#each logs as log}
+					<div class="log-entry">{log}</div>
+				{/each}
+			{/if}
+		</div>
+	</div>
+
+	<!-- Help -->
+	<div class="help-section">
+		<h3>How This Works</h3>
+		<ul>
+			<li>This tool fetches cover images for records that don't have custom covers uploaded.</li>
+			<li>It searches Google Books API first (usually better quality covers).</li>
+			<li>If not found, it tries Open Library API as a fallback.</li>
+			<li>Found covers are saved to the database and will display immediately.</li>
+			<li>You can pause and resume the process at any time.</li>
+			<li>Smaller batch sizes are slower but less likely to hit rate limits.</li>
+			<li>
+				This does NOT override custom uploaded covers - only fills in missing ones.
+			</li>
+		</ul>
+	</div>
+</div>
+
+<style>
+	.fetch-covers-page {
+		max-width: 1200px;
+		margin: 0 auto;
+		padding: 2rem;
+	}
+
+	.header {
+		margin-bottom: 2rem;
+	}
+
+	.header h1 {
+		margin: 0 0 0.5rem 0;
+		color: #333;
+	}
+
+	.header p {
+		margin: 0;
+		color: #666;
+	}
+
+	.stats-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 1rem;
+		margin-bottom: 2rem;
+	}
+
+	.stat-card {
+		background: white;
+		padding: 1.5rem;
+		border-radius: 8px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+		text-align: center;
+	}
+
+	.stat-value {
+		font-size: 2.5rem;
+		font-weight: bold;
+		color: #667eea;
+		margin-bottom: 0.5rem;
+	}
+
+	.stat-label {
+		font-size: 0.875rem;
+		color: #666;
+	}
+
+	.message {
+		background: #d1ecf1;
+		color: #0c5460;
+		padding: 1rem;
+		border-radius: 4px;
+		margin-bottom: 1rem;
+		border: 1px solid #bee5eb;
+	}
+
+	.progress-section {
+		margin-bottom: 2rem;
+	}
+
+	.progress-label {
+		margin-bottom: 0.5rem;
+		font-weight: 500;
+		color: #333;
+	}
+
+	.progress-bar {
+		width: 100%;
+		height: 30px;
+		background: #e0e0e0;
+		border-radius: 15px;
+		overflow: hidden;
+		box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+	}
+
+	.progress-fill {
+		height: 100%;
+		background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+		transition: width 0.3s ease;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: white;
+		font-weight: bold;
+	}
+
+	.controls {
+		background: white;
+		padding: 1.5rem;
+		border-radius: 8px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+		margin-bottom: 2rem;
+	}
+
+	.batch-size-control {
+		margin-bottom: 1.5rem;
+	}
+
+	.batch-size-control label {
+		display: block;
+		margin-bottom: 0.5rem;
+		font-weight: 500;
+		color: #333;
+	}
+
+	.batch-size-control input {
+		width: 100px;
+		padding: 0.5rem;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		font-size: 1rem;
+	}
+
+	.batch-size-control small {
+		display: block;
+		margin-top: 0.25rem;
+		color: #666;
+	}
+
+	.button-group {
+		display: flex;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+
+	.btn-primary,
+	.btn-secondary,
+	.btn-warning {
+		padding: 0.75rem 1.5rem;
+		border-radius: 4px;
+		font-size: 1rem;
+		cursor: pointer;
+		border: none;
+		transition: all 0.2s;
+	}
+
+	.btn-primary {
+		background: #667eea;
+		color: white;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		background: #5568d3;
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: #e0e0e0;
+		color: #333;
+	}
+
+	.btn-secondary:hover {
+		background: #d0d0d0;
+	}
+
+	.btn-warning {
+		background: #f39c12;
+		color: white;
+	}
+
+	.btn-warning:hover {
+		background: #e67e22;
+	}
+
+	.log-section {
+		background: white;
+		padding: 1.5rem;
+		border-radius: 8px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+		margin-bottom: 2rem;
+	}
+
+	.log-section h2 {
+		margin: 0 0 1rem 0;
+		font-size: 1.25rem;
+		color: #333;
+	}
+
+	.log-container {
+		max-height: 400px;
+		overflow-y: auto;
+		background: #f8f9fa;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		padding: 1rem;
+		font-family: 'Courier New', monospace;
+		font-size: 0.875rem;
+	}
+
+	.log-empty {
+		color: #999;
+		text-align: center;
+		padding: 2rem;
+	}
+
+	.log-entry {
+		padding: 0.25rem 0;
+		border-bottom: 1px solid #e0e0e0;
+	}
+
+	.log-entry:last-child {
+		border-bottom: none;
+	}
+
+	.help-section {
+		background: #f8f9fa;
+		padding: 1.5rem;
+		border-radius: 8px;
+		border: 1px solid #ddd;
+	}
+
+	.help-section h3 {
+		margin: 0 0 1rem 0;
+		color: #333;
+	}
+
+	.help-section ul {
+		margin: 0;
+		padding-left: 1.5rem;
+	}
+
+	.help-section li {
+		margin-bottom: 0.5rem;
+		color: #666;
+	}
+</style>

--- a/src/routes/admin/cataloging/fetch-covers/+page.ts
+++ b/src/routes/admin/cataloging/fetch-covers/+page.ts
@@ -1,0 +1,6 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent }) => {
+	const { supabase } = await parent();
+	return { supabase };
+};

--- a/src/routes/api/fetch-covers/+server.ts
+++ b/src/routes/api/fetch-covers/+server.ts
@@ -1,0 +1,177 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	const { supabase, safeGetSession } = locals;
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	try {
+		const { batchSize = 10 } = await request.json();
+
+		// Get records without custom covers
+		const { data: records, error: fetchError } = await supabase
+			.from('marc_records')
+			.select('id, isbn, title_statement, main_entry_personal_name, cover_image_url')
+			.is('cover_image_url', null)
+			.limit(batchSize);
+
+		if (fetchError) {
+			return json({ error: fetchError.message }, { status: 500 });
+		}
+
+		if (!records || records.length === 0) {
+			return json({
+				processed: 0,
+				found: 0,
+				remaining: 0,
+				message: 'No records to process'
+			});
+		}
+
+		const results = [];
+		let foundCount = 0;
+
+		for (const record of records) {
+			const isbn = record.isbn;
+			const title = record.title_statement?.a;
+			const author = record.main_entry_personal_name?.a;
+
+			let coverUrl: string | null = null;
+
+			// Try Google Books first
+			if (isbn) {
+				coverUrl = await tryGoogleBooks(isbn);
+			}
+
+			// Fallback to Open Library
+			if (!coverUrl && (isbn || title)) {
+				coverUrl = await tryOpenLibrary(isbn, title, author);
+			}
+
+			if (coverUrl) {
+				// Save to database
+				const { error: updateError } = await supabase
+					.from('marc_records')
+					.update({ cover_image_url: coverUrl })
+					.eq('id', record.id);
+
+				if (!updateError) {
+					foundCount++;
+					results.push({
+						id: record.id,
+						title: title || 'Untitled',
+						coverUrl,
+						success: true
+					});
+				} else {
+					results.push({
+						id: record.id,
+						title: title || 'Untitled',
+						error: updateError.message,
+						success: false
+					});
+				}
+			} else {
+				results.push({
+					id: record.id,
+					title: title || 'Untitled',
+					coverUrl: null,
+					success: false
+				});
+			}
+		}
+
+		// Get count of remaining records
+		const { count: remainingCount } = await supabase
+			.from('marc_records')
+			.select('id', { count: 'exact', head: true })
+			.is('cover_image_url', null);
+
+		return json({
+			processed: records.length,
+			found: foundCount,
+			remaining: remainingCount || 0,
+			results
+		});
+
+	} catch (error: any) {
+		console.error('Cover fetch error:', error);
+		return json({ error: error.message }, { status: 500 });
+	}
+};
+
+async function tryGoogleBooks(isbn: string): Promise<string | null> {
+	try {
+		const cleanISBN = isbn.replace(/[^0-9X]/gi, '');
+		const response = await fetch(
+			`https://www.googleapis.com/books/v1/volumes?q=isbn:${cleanISBN}`
+		);
+
+		if (!response.ok) return null;
+
+		const data = await response.json();
+
+		if (data.items && data.items[0]?.volumeInfo?.imageLinks) {
+			const imageLinks = data.items[0].volumeInfo.imageLinks;
+			return (
+				imageLinks.large ||
+				imageLinks.medium ||
+				imageLinks.thumbnail ||
+				imageLinks.smallThumbnail ||
+				null
+			);
+		}
+
+		return null;
+	} catch (error) {
+		return null;
+	}
+}
+
+async function tryOpenLibrary(
+	isbn: string | null,
+	title: string | null,
+	author: string | null
+): Promise<string | null> {
+	try {
+		// Try ISBN first
+		if (isbn) {
+			const cleanISBN = isbn.replace(/[^0-9X]/gi, '');
+			const coverUrl = `https://covers.openlibrary.org/b/isbn/${cleanISBN}-L.jpg`;
+
+			const response = await fetch(coverUrl, { method: 'HEAD' });
+			if (response.ok) {
+				return coverUrl;
+			}
+		}
+
+		// Try title/author search
+		if (title) {
+			let query = `title:${title}`;
+			if (author) {
+				query += ` author:${author}`;
+			}
+
+			const response = await fetch(
+				`https://openlibrary.org/search.json?${new URLSearchParams({ q: query, limit: '1' })}`
+			);
+
+			if (!response.ok) return null;
+
+			const data = await response.json();
+
+			if (data.docs && data.docs[0]?.cover_i) {
+				const coverId = data.docs[0].cover_i;
+				return `https://covers.openlibrary.org/b/id/${coverId}-L.jpg`;
+			}
+		}
+
+		return null;
+	} catch (error) {
+		return null;
+	}
+}


### PR DESCRIPTION
Features:
- New admin page: /admin/cataloging/fetch-covers
- Batch processing API endpoint: /api/fetch-covers
- Fetches covers for all records without custom covers
- Real-time progress tracking and statistics
- Pause/resume functionality
- Activity log with timestamps
- Configurable batch size (1-50 records)
- Searches Google Books API first, falls back to Open Library
- Does NOT override custom uploaded covers
- Shows stats: total, processed, found, remaining
- Progress bar with percentage
- Rate limiting protection (1 second delay between batches)

UI Features:
- Stats cards showing totals
- Progress bar visualization
- Live activity log (last 100 entries)
- Batch size control
- Start/Pause/Resume/Reset controls
- Help section with instructions
- Refresh stats button

Added link to cataloging index page for easy access.

Use case: Retroactively fetch covers for entire existing catalog in one automated process instead of manually uploading each one.