### PR TITLE
Add admin configuration for faceted search

### DIFF
--- a/migrations/018_faceted_search_configuration.sql
+++ b/migrations/018_faceted_search_configuration.sql
@@ -1,0 +1,551 @@
+-- Migration: Faceted Search Configuration System
+-- Description: Enables admin-configurable faceted search without code changes
+-- Created: 2025-12-30
+
+-- =============================================================================
+-- FACET CONFIGURATION TABLE
+-- =============================================================================
+
+CREATE TABLE facet_configuration (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Facet identification
+  facet_key VARCHAR(50) NOT NULL UNIQUE,
+  facet_label VARCHAR(100) NOT NULL,
+  facet_description TEXT,
+
+  -- Data source configuration
+  source_type VARCHAR(50) NOT NULL, -- 'marc_field', 'database_column', 'items_field', 'computed'
+  source_field VARCHAR(100) NOT NULL, -- MARC field (e.g., '650', 'material_type') or db column
+  source_subfield VARCHAR(10), -- MARC subfield (e.g., 'a' for 650$a)
+
+  -- Display configuration
+  display_type VARCHAR(50) DEFAULT 'checkbox_list', -- 'checkbox_list', 'date_range', 'numeric_range', 'tag_cloud'
+  display_order INTEGER DEFAULT 0,
+  is_enabled BOOLEAN DEFAULT true,
+  is_collapsed_by_default BOOLEAN DEFAULT false,
+  show_count BOOLEAN DEFAULT true,
+  max_items INTEGER DEFAULT 10,
+  show_more_threshold INTEGER DEFAULT 5,
+
+  -- Aggregation settings
+  aggregation_method VARCHAR(50) DEFAULT 'distinct_values', -- 'distinct_values', 'decade_buckets', 'year_buckets', 'custom_ranges'
+  bucket_size INTEGER, -- For numeric/date bucketing (e.g., 10 for decades)
+  custom_ranges JSONB, -- For custom range definitions
+
+  -- Sorting
+  sort_by VARCHAR(50) DEFAULT 'count_desc', -- 'count_desc', 'count_asc', 'label_asc', 'label_desc', 'custom'
+  custom_sort_order TEXT[], -- For manual ordering of facet values
+
+  -- Value formatting
+  value_formatter VARCHAR(50), -- 'material_type', 'language_code', 'year', 'custom'
+  value_format_mapping JSONB, -- Custom value to label mapping
+
+  -- Filtering
+  filter_param_name VARCHAR(50), -- URL parameter name (e.g., 'material_types', 'languages')
+  multi_select BOOLEAN DEFAULT true,
+  apply_to_search_field VARCHAR(100), -- Which search field this facet filters
+
+  -- Performance
+  cache_enabled BOOLEAN DEFAULT true,
+  cache_ttl INTEGER DEFAULT 3600, -- Cache time-to-live in seconds
+
+  -- Conditional display
+  show_only_for_search_types VARCHAR(50)[], -- e.g., ['keyword', 'advanced']
+  min_results_to_show INTEGER DEFAULT 1,
+
+  -- Access control
+  public_visible BOOLEAN DEFAULT true,
+  staff_only BOOLEAN DEFAULT false,
+
+  -- Metadata
+  is_active BOOLEAN DEFAULT true,
+  updated_by UUID REFERENCES auth.users(id)
+);
+
+-- Index for quick lookups
+CREATE INDEX idx_facet_config_key ON facet_configuration(facet_key);
+CREATE INDEX idx_facet_config_enabled ON facet_configuration(is_enabled, is_active);
+CREATE INDEX idx_facet_config_order ON facet_configuration(display_order) WHERE is_enabled = true AND is_active = true;
+
+-- =============================================================================
+-- FACET VALUES CACHE TABLE
+-- =============================================================================
+
+CREATE TABLE facet_values_cache (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  facet_key VARCHAR(50) NOT NULL REFERENCES facet_configuration(facet_key) ON DELETE CASCADE,
+
+  -- Facet value
+  value TEXT NOT NULL,
+  label TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+
+  -- Context (for filtered caches)
+  filter_context JSONB, -- Stores active filters when this cache was computed
+
+  -- Cache metadata
+  cached_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at TIMESTAMPTZ,
+
+  -- Composite unique constraint
+  UNIQUE(facet_key, value, filter_context)
+);
+
+-- Indexes for cache lookups
+CREATE INDEX idx_facet_cache_key ON facet_values_cache(facet_key);
+CREATE INDEX idx_facet_cache_expires ON facet_values_cache(expires_at);
+CREATE INDEX idx_facet_cache_context ON facet_values_cache USING gin(filter_context);
+
+-- =============================================================================
+-- TRIGGERS
+-- =============================================================================
+
+-- Update timestamp trigger
+CREATE OR REPLACE FUNCTION update_facet_config_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER facet_config_updated
+  BEFORE UPDATE ON facet_configuration
+  FOR EACH ROW
+  EXECUTE FUNCTION update_facet_config_timestamp();
+
+-- Invalidate cache when configuration changes
+CREATE OR REPLACE FUNCTION invalidate_facet_cache()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Delete cached values for this facet
+  DELETE FROM facet_values_cache WHERE facet_key = NEW.facet_key;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER facet_config_invalidate_cache
+  AFTER UPDATE ON facet_configuration
+  FOR EACH ROW
+  WHEN (OLD.source_field IS DISTINCT FROM NEW.source_field
+    OR OLD.aggregation_method IS DISTINCT FROM NEW.aggregation_method
+    OR OLD.bucket_size IS DISTINCT FROM NEW.bucket_size)
+  EXECUTE FUNCTION invalidate_facet_cache();
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- =============================================================================
+
+ALTER TABLE facet_configuration ENABLE ROW LEVEL SECURITY;
+ALTER TABLE facet_values_cache ENABLE ROW LEVEL SECURITY;
+
+-- Public read access to enabled facets
+CREATE POLICY "Public read access to enabled facets"
+  ON facet_configuration FOR SELECT
+  TO anon, authenticated
+  USING (is_enabled = true AND is_active = true AND (staff_only = false OR auth.role() = 'authenticated'));
+
+-- Admin write access
+CREATE POLICY "Authenticated users can manage facets"
+  ON facet_configuration FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- Public read access to cache
+CREATE POLICY "Public read access to facet cache"
+  ON facet_values_cache FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- Admin write access to cache
+CREATE POLICY "Authenticated users can manage cache"
+  ON facet_values_cache FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- =============================================================================
+-- DEFAULT FACET CONFIGURATIONS
+-- =============================================================================
+
+-- 1. Material Type Facet
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  value_formatter,
+  value_format_mapping,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled
+) VALUES (
+  'material_type',
+  'Material Type',
+  'Filter by type of material (books, DVDs, etc.)',
+  'database_column',
+  'material_type',
+  'checkbox_list',
+  1,
+  'distinct_values',
+  'count_desc',
+  'material_type',
+  '{"book":"Books","ebook":"E-Books","serial":"Serials/Journals","audiobook":"Audiobooks","dvd":"DVDs","cdrom":"CD-ROMs","electronic":"Electronic Resources","manuscript":"Manuscripts","map":"Maps","music":"Music","visual-material":"Visual Materials"}',
+  'material_types',
+  'material_type',
+  15,
+  true
+);
+
+-- 2. Language Facet
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  value_formatter,
+  value_format_mapping,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled
+) VALUES (
+  'language',
+  'Language',
+  'Filter by language of the material',
+  'database_column',
+  'language_code',
+  'checkbox_list',
+  2,
+  'distinct_values',
+  'count_desc',
+  'language_code',
+  '{"eng":"English","spa":"Spanish","fre":"French","ger":"German","ita":"Italian","rus":"Russian","chi":"Chinese","jpn":"Japanese","ara":"Arabic","por":"Portuguese"}',
+  'languages',
+  'language_code',
+  10,
+  true
+);
+
+-- 3. Publication Decade Facet
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  source_subfield,
+  display_type,
+  display_order,
+  aggregation_method,
+  bucket_size,
+  sort_by,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled
+) VALUES (
+  'publication_decade',
+  'Publication Decade',
+  'Filter by decade of publication',
+  'marc_field',
+  'publication_info',
+  'c',
+  'checkbox_list',
+  3,
+  'decade_buckets',
+  10,
+  'label_desc',
+  'publication_decades',
+  'publication_info->c',
+  10,
+  true
+);
+
+-- 4. Availability Facet
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  value_format_mapping,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled
+) VALUES (
+  'availability',
+  'Availability',
+  'Filter by availability status',
+  'items_field',
+  'status',
+  'checkbox_list',
+  4,
+  'distinct_values',
+  'custom',
+  '{"available":"Available Now","checked_out":"Checked Out","unavailable":"Unavailable"}',
+  'availability',
+  'items.status',
+  5,
+  true
+);
+
+-- 5. Location Facet
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled
+) VALUES (
+  'location',
+  'Location',
+  'Filter by physical location',
+  'items_field',
+  'location',
+  'checkbox_list',
+  5,
+  'distinct_values',
+  'label_asc',
+  'locations',
+  'items.location',
+  10,
+  true
+);
+
+-- 6. Subject Facet (Top-level)
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  source_subfield,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled,
+  is_collapsed_by_default
+) VALUES (
+  'subject',
+  'Subject',
+  'Filter by subject heading',
+  'marc_field',
+  'subject_topical',
+  'a',
+  'checkbox_list',
+  6,
+  'distinct_values',
+  'count_desc',
+  'subjects',
+  'subject_topical',
+  15,
+  true,
+  true
+);
+
+-- 7. Author Facet (Top authors)
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  source_subfield,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled,
+  is_collapsed_by_default
+) VALUES (
+  'author',
+  'Author',
+  'Filter by author',
+  'marc_field',
+  'main_entry_personal_name',
+  'a',
+  'checkbox_list',
+  7,
+  'distinct_values',
+  'count_desc',
+  'authors',
+  'main_entry_personal_name->a',
+  10,
+  false,
+  true
+);
+
+-- 8. Publication Year Range Facet
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  source_subfield,
+  display_type,
+  display_order,
+  aggregation_method,
+  sort_by,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled,
+  is_collapsed_by_default
+) VALUES (
+  'publication_year_range',
+  'Publication Year',
+  'Filter by publication year range',
+  'marc_field',
+  'publication_info',
+  'c',
+  'date_range',
+  8,
+  'year_buckets',
+  'label_desc',
+  'year_range',
+  'publication_info->c',
+  20,
+  false,
+  true
+);
+
+-- 9. Call Number Range Facet (for browsing)
+INSERT INTO facet_configuration (
+  facet_key,
+  facet_label,
+  facet_description,
+  source_type,
+  source_field,
+  display_type,
+  display_order,
+  aggregation_method,
+  custom_ranges,
+  sort_by,
+  filter_param_name,
+  apply_to_search_field,
+  max_items,
+  is_enabled,
+  is_collapsed_by_default
+) VALUES (
+  'call_number_range',
+  'Call Number Range',
+  'Browse by call number classification',
+  'items_field',
+  'call_number',
+  'checkbox_list',
+  9,
+  'custom_ranges',
+  '[
+    {"label":"000-099 Computer Science, Information & General Works","min":"000","max":"099"},
+    {"label":"100-199 Philosophy & Psychology","min":"100","max":"199"},
+    {"label":"200-299 Religion","min":"200","max":"299"},
+    {"label":"300-399 Social Sciences","min":"300","max":"399"},
+    {"label":"400-499 Language","min":"400","max":"499"},
+    {"label":"500-599 Science","min":"500","max":"599"},
+    {"label":"600-699 Technology","min":"600","max":"699"},
+    {"label":"700-799 Arts & Recreation","min":"700","max":"799"},
+    {"label":"800-899 Literature","min":"800","max":"899"},
+    {"label":"900-999 History & Geography","min":"900","max":"999"}
+  ]',
+  'label_asc',
+  'call_number_ranges',
+  'items.call_number',
+  10,
+  false,
+  true
+);
+
+-- =============================================================================
+-- HELPER FUNCTIONS
+-- =============================================================================
+
+-- Function to refresh facet cache for a specific facet
+CREATE OR REPLACE FUNCTION refresh_facet_cache(facet_key_param VARCHAR)
+RETURNS INTEGER AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  -- Delete old cache entries for this facet
+  DELETE FROM facet_values_cache WHERE facet_key = facet_key_param;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  -- Note: Cache will be rebuilt on next query
+  -- or you can implement specific rebuild logic here
+
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to refresh all facet caches
+CREATE OR REPLACE FUNCTION refresh_all_facet_caches()
+RETURNS INTEGER AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM facet_values_cache;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to clean expired cache entries
+CREATE OR REPLACE FUNCTION clean_expired_facet_cache()
+RETURNS INTEGER AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM facet_values_cache WHERE expires_at < NOW();
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =============================================================================
+-- COMMENTS
+-- =============================================================================
+
+COMMENT ON TABLE facet_configuration IS 'Configuration for dynamic faceted search - allows admins to create and configure facets without code changes';
+COMMENT ON TABLE facet_values_cache IS 'Materialized cache of facet values and counts for performance optimization';
+
+COMMENT ON COLUMN facet_configuration.source_type IS 'Type of data source: marc_field (JSONB MARC field), database_column (direct column), items_field (from items table), computed (custom logic)';
+COMMENT ON COLUMN facet_configuration.display_type IS 'UI display type: checkbox_list, date_range, numeric_range, tag_cloud';
+COMMENT ON COLUMN facet_configuration.aggregation_method IS 'How to aggregate values: distinct_values, decade_buckets, year_buckets, custom_ranges';
+COMMENT ON COLUMN facet_configuration.sort_by IS 'How to sort facet values: count_desc, count_asc, label_asc, label_desc, custom';
+COMMENT ON COLUMN facet_configuration.value_formatter IS 'How to format facet values for display: material_type, language_code, year, custom';

--- a/src/lib/utils/facets.ts
+++ b/src/lib/utils/facets.ts
@@ -1,0 +1,445 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SearchParams } from '../../routes/catalog/search/results/+page.server';
+
+export interface FacetConfig {
+	id: string;
+	facet_key: string;
+	facet_label: string;
+	source_type: 'database_column' | 'marc_field' | 'items_field' | 'computed';
+	source_field: string;
+	source_subfield?: string;
+	display_type: 'checkbox_list' | 'date_range' | 'numeric_range' | 'tag_cloud';
+	aggregation_method: 'distinct_values' | 'decade_buckets' | 'year_buckets' | 'custom_ranges';
+	bucket_size?: number;
+	custom_ranges?: any;
+	sort_by: 'count_desc' | 'count_asc' | 'label_asc' | 'label_desc' | 'custom';
+	custom_sort_order?: string[];
+	value_formatter?: string;
+	value_format_mapping?: Record<string, string>;
+	filter_param_name: string;
+	max_items: number;
+	show_count: boolean;
+	is_enabled: boolean;
+	is_active: boolean;
+}
+
+export interface Facet {
+	value: string;
+	label: string;
+	count: number;
+}
+
+export interface DynamicFacetGroup {
+	[facetKey: string]: Facet[];
+}
+
+/**
+ * Load enabled facet configurations from database
+ */
+export async function loadFacetConfigs(supabase: SupabaseClient): Promise<FacetConfig[]> {
+	const { data, error } = await supabase
+		.from('facet_configuration')
+		.select('*')
+		.eq('is_enabled', true)
+		.eq('is_active', true)
+		.order('display_order', { ascending: true });
+
+	if (error) {
+		console.error('Error loading facet configs:', error);
+		return [];
+	}
+
+	return data || [];
+}
+
+/**
+ * Compute all facets based on configurations
+ */
+export async function computeDynamicFacets(
+	supabase: SupabaseClient,
+	configs: FacetConfig[],
+	params: SearchParams
+): Promise<DynamicFacetGroup> {
+	const facets: DynamicFacetGroup = {};
+
+	// Compute each facet in parallel
+	await Promise.all(
+		configs.map(async (config) => {
+			const facetValues = await computeSingleFacet(supabase, config, params);
+			facets[config.facet_key] = facetValues;
+		})
+	);
+
+	return facets;
+}
+
+/**
+ * Compute a single facet based on its configuration
+ */
+async function computeSingleFacet(
+	supabase: SupabaseClient,
+	config: FacetConfig,
+	params: SearchParams
+): Promise<Facet[]> {
+	try {
+		switch (config.source_type) {
+			case 'database_column':
+				return await computeDatabaseColumnFacet(supabase, config, params);
+			case 'marc_field':
+				return await computeMarcFieldFacet(supabase, config, params);
+			case 'items_field':
+				return await computeItemsFieldFacet(supabase, config, params);
+			case 'computed':
+				return await computeComputedFacet(supabase, config, params);
+			default:
+				console.warn(`Unknown source type: ${config.source_type}`);
+				return [];
+		}
+	} catch (error) {
+		console.error(`Error computing facet ${config.facet_key}:`, error);
+		return [];
+	}
+}
+
+/**
+ * Compute facet from a direct database column
+ */
+async function computeDatabaseColumnFacet(
+	supabase: SupabaseClient,
+	config: FacetConfig,
+	params: SearchParams
+): Promise<Facet[]> {
+	// Build base query without this facet's filter
+	let query = supabase.from('marc_records').select(config.source_field);
+
+	// Apply other filters
+	query = applyBaseFilters(query, params, [config.filter_param_name]);
+
+	const { data, error } = await query;
+
+	if (error || !data) return [];
+
+	// Count occurrences
+	const counts = new Map<string, number>();
+	data.forEach((record: any) => {
+		const value = record[config.source_field];
+		if (value) {
+			counts.set(value, (counts.get(value) || 0) + 1);
+		}
+	});
+
+	return formatFacetValues(counts, config);
+}
+
+/**
+ * Compute facet from a MARC field
+ */
+async function computeMarcFieldFacet(
+	supabase: SupabaseClient,
+	config: FacetConfig,
+	params: SearchParams
+): Promise<Facet[]> {
+	let query = supabase.from('marc_records').select(config.source_field);
+
+	query = applyBaseFilters(query, params, [config.filter_param_name]);
+
+	const { data, error } = await query;
+
+	if (error || !data) return [];
+
+	const counts = new Map<string, number>();
+
+	data.forEach((record: any) => {
+		const fieldData = record[config.source_field];
+
+		if (!fieldData) return;
+
+		// Handle JSONB fields
+		let values: any[] = [];
+
+		if (Array.isArray(fieldData)) {
+			// Array of JSONB objects (e.g., subject_topical)
+			values = fieldData.map((item) =>
+				config.source_subfield ? item[config.source_subfield] : item
+			);
+		} else if (typeof fieldData === 'object') {
+			// Single JSONB object (e.g., publication_info)
+			const value = config.source_subfield ? fieldData[config.source_subfield] : fieldData;
+			values = [value];
+		} else {
+			values = [fieldData];
+		}
+
+		values.forEach((value) => {
+			if (value) {
+				// Apply aggregation method
+				const processedValue = applyAggregation(value, config);
+				if (processedValue) {
+					counts.set(processedValue, (counts.get(processedValue) || 0) + 1);
+				}
+			}
+		});
+	});
+
+	return formatFacetValues(counts, config);
+}
+
+/**
+ * Compute facet from items table field
+ */
+async function computeItemsFieldFacet(
+	supabase: SupabaseClient,
+	config: FacetConfig,
+	params: SearchParams
+): Promise<Facet[]> {
+	// Special handling for items fields (like location, status)
+	const fieldName = config.source_field;
+
+	let query = supabase.from('marc_records').select(`
+		id,
+		items:items(${fieldName})
+	`);
+
+	query = applyBaseFilters(query, params, [config.filter_param_name]);
+
+	const { data, error } = await query;
+
+	if (error || !data) return [];
+
+	const counts = new Map<string, number>();
+
+	data.forEach((record: any) => {
+		const items = record.items || [];
+
+		if (fieldName === 'status') {
+			// Special aggregation for availability
+			const hasAvailable = items.some((item: any) => item.status === 'available');
+			const hasCheckedOut = items.some((item: any) => item.status === 'checked_out');
+
+			if (hasAvailable) {
+				counts.set('available', (counts.get('available') || 0) + 1);
+			} else if (hasCheckedOut) {
+				counts.set('checked_out', (counts.get('checked_out') || 0) + 1);
+			} else {
+				counts.set('unavailable', (counts.get('unavailable') || 0) + 1);
+			}
+		} else {
+			// For other fields like location, count distinct values
+			const values = new Set(items.map((item: any) => item[fieldName]).filter(Boolean));
+			values.forEach((value) => {
+				counts.set(value as string, (counts.get(value as string) || 0) + 1);
+			});
+		}
+	});
+
+	return formatFacetValues(counts, config);
+}
+
+/**
+ * Compute facet with custom logic (placeholder)
+ */
+async function computeComputedFacet(
+	supabase: SupabaseClient,
+	config: FacetConfig,
+	params: SearchParams
+): Promise<Facet[]> {
+	// Placeholder for custom computed facets
+	// Can be extended with custom logic based on facet_key
+	console.warn(`Computed facets not yet implemented for: ${config.facet_key}`);
+	return [];
+}
+
+/**
+ * Apply aggregation method to a value
+ */
+function applyAggregation(value: any, config: FacetConfig): string | null {
+	switch (config.aggregation_method) {
+		case 'decade_buckets':
+			if (/^\d{4}/.test(value)) {
+				const year = parseInt(value.substring(0, 4));
+				const decade = Math.floor(year / 10) * 10;
+				return `${decade}s`;
+			}
+			return null;
+
+		case 'year_buckets':
+			if (/^\d{4}/.test(value)) {
+				return value.substring(0, 4);
+			}
+			return null;
+
+		case 'custom_ranges':
+			// Would need to implement range matching based on config.custom_ranges
+			return value;
+
+		case 'distinct_values':
+		default:
+			return value;
+	}
+}
+
+/**
+ * Format facet values with labels and sorting
+ */
+function formatFacetValues(counts: Map<string, number>, config: FacetConfig): Facet[] {
+	let facets: Facet[] = Array.from(counts.entries()).map(([value, count]) => ({
+		value,
+		label: formatValue(value, config),
+		count
+	}));
+
+	// Apply sorting
+	facets = sortFacets(facets, config);
+
+	// Apply max items limit
+	if (config.max_items) {
+		facets = facets.slice(0, config.max_items);
+	}
+
+	// Filter out zero counts
+	facets = facets.filter((f) => f.count > 0);
+
+	return facets;
+}
+
+/**
+ * Format a value for display
+ */
+function formatValue(value: string, config: FacetConfig): string {
+	// First check custom mapping
+	if (config.value_format_mapping && config.value_format_mapping[value]) {
+		return config.value_format_mapping[value];
+	}
+
+	// Then check formatter type
+	if (config.value_formatter) {
+		switch (config.value_formatter) {
+			case 'material_type':
+				return formatMaterialType(value);
+			case 'language_code':
+				return formatLanguage(value);
+			case 'year':
+				return value;
+			default:
+				return value;
+		}
+	}
+
+	return value;
+}
+
+/**
+ * Sort facets based on configuration
+ */
+function sortFacets(facets: Facet[], config: FacetConfig): Facet[] {
+	switch (config.sort_by) {
+		case 'count_desc':
+			return facets.sort((a, b) => b.count - a.count);
+		case 'count_asc':
+			return facets.sort((a, b) => a.count - b.count);
+		case 'label_asc':
+			return facets.sort((a, b) => a.label.localeCompare(b.label));
+		case 'label_desc':
+			return facets.sort((a, b) => b.label.localeCompare(a.label));
+		case 'custom':
+			if (config.custom_sort_order) {
+				return facets.sort((a, b) => {
+					const aIndex = config.custom_sort_order!.indexOf(a.value);
+					const bIndex = config.custom_sort_order!.indexOf(b.value);
+					if (aIndex === -1) return 1;
+					if (bIndex === -1) return -1;
+					return aIndex - bIndex;
+				});
+			}
+			return facets;
+		default:
+			return facets;
+	}
+}
+
+/**
+ * Apply base search filters (excluding the facet being computed)
+ */
+function applyBaseFilters(query: any, params: SearchParams, excludeParams: string[]): any {
+	// Apply all filters except the ones we're faceting on
+	if (params.q && !excludeParams.includes('q')) {
+		query = query.textSearch('search_vector', params.q, {
+			type: 'websearch',
+			config: 'english'
+		});
+	}
+
+	if (params.title && !excludeParams.includes('title')) {
+		query = query.ilike('title_statement->>a', `%${params.title}%`);
+	}
+
+	if (params.author && !excludeParams.includes('author')) {
+		query = query.ilike('main_entry_personal_name->>a', `%${params.author}%`);
+	}
+
+	if (params.isbn && !excludeParams.includes('isbn')) {
+		query = query.ilike('isbn', `%${params.isbn.replace(/-/g, '')}%`);
+	}
+
+	if (params.publisher && !excludeParams.includes('publisher')) {
+		query = query.ilike('publication_info->>b', `%${params.publisher}%`);
+	}
+
+	// Year filter
+	if (!excludeParams.includes('year_from') && params.year_from) {
+		query = query.gte('publication_info->>c', params.year_from);
+	}
+	if (!excludeParams.includes('year_to') && params.year_to) {
+		query = query.lte('publication_info->>c', params.year_to);
+	}
+
+	// Dynamic facet filters
+	if (!excludeParams.includes('material_types') && params.material_types?.length) {
+		query = query.in('material_type', params.material_types);
+	}
+
+	if (!excludeParams.includes('languages') && params.languages?.length) {
+		query = query.in('language_code', params.languages);
+	}
+
+	return query;
+}
+
+/**
+ * Format material type for display
+ */
+function formatMaterialType(type: string): string {
+	const typeMap: Record<string, string> = {
+		book: 'Books',
+		ebook: 'E-Books',
+		serial: 'Serials/Journals',
+		audiobook: 'Audiobooks',
+		dvd: 'DVDs',
+		cdrom: 'CD-ROMs',
+		electronic: 'Electronic Resources',
+		manuscript: 'Manuscripts',
+		map: 'Maps',
+		music: 'Music',
+		'visual-material': 'Visual Materials'
+	};
+	return typeMap[type] || type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+/**
+ * Format language code for display
+ */
+function formatLanguage(code: string): string {
+	const languageMap: Record<string, string> = {
+		eng: 'English',
+		spa: 'Spanish',
+		fre: 'French',
+		ger: 'German',
+		ita: 'Italian',
+		rus: 'Russian',
+		chi: 'Chinese',
+		jpn: 'Japanese',
+		ara: 'Arabic',
+		por: 'Portuguese'
+	};
+	return languageMap[code] || code.toUpperCase();
+}

--- a/src/routes/admin/search-config/+page.server.ts
+++ b/src/routes/admin/search-config/+page.server.ts
@@ -14,6 +14,12 @@ export const load: PageServerLoad = async ({ locals: { supabase } }) => {
 		.eq('is_active', true)
 		.single();
 
+	// Fetch facet configurations (including inactive for admin view)
+	const { data: facets, error: facetsError } = await supabase
+		.from('facet_configuration')
+		.select('*')
+		.order('display_order', { ascending: true });
+
 	// Return with defaults if not found
 	return {
 		fields: fields || [],
@@ -38,6 +44,7 @@ export const load: PageServerLoad = async ({ locals: { supabase } }) => {
 			enable_boolean_operators: true,
 			default_sort: 'relevance',
 			available_sort_options: ['relevance', 'title', 'author', 'date_newest', 'date_oldest']
-		}
+		},
+		facets: facets || []
 	};
 };

--- a/src/routes/admin/search-config/+page.svelte
+++ b/src/routes/admin/search-config/+page.svelte
@@ -5,12 +5,18 @@
 
 	let fields = $state([...data.fields]);
 	let config = $state({ ...data.config });
+	let facets = $state([...data.facets]);
 	let message = $state('');
 	let saving = $state(false);
+	let refreshingCache = $state(false);
 	let activeTab = $state<'fields' | 'settings' | 'facets'>('fields');
+	let editingFacet = $state<any>(null);
+	let showNewFacetForm = $state(false);
 
-	// Drag and drop
+	// Drag and drop for fields
 	let draggedIndex = $state<number | null>(null);
+	// Drag and drop for facets
+	let draggedFacetIndex = $state<number | null>(null);
 
 	function handleDragStart(index: number) {
 		draggedIndex = index;
@@ -32,6 +38,219 @@
 		// Update display_order based on new positions
 		fields = fields.map((field, index) => ({ ...field, display_order: index + 1 }));
 		draggedIndex = null;
+	}
+
+	// Facet drag and drop
+	function handleFacetDragStart(index: number) {
+		draggedFacetIndex = index;
+	}
+
+	function handleFacetDragOver(e: DragEvent, index: number) {
+		e.preventDefault();
+		if (draggedFacetIndex === null || draggedFacetIndex === index) return;
+
+		const newFacets = [...facets];
+		const draggedItem = newFacets[draggedFacetIndex];
+		newFacets.splice(draggedFacetIndex, 1);
+		newFacets.splice(index, 0, draggedItem);
+		facets = newFacets;
+		draggedFacetIndex = index;
+	}
+
+	function handleFacetDragEnd() {
+		// Update display_order based on new positions
+		facets = facets.map((facet, index) => ({ ...facet, display_order: index }));
+		draggedFacetIndex = null;
+	}
+
+	async function saveFacets() {
+		saving = true;
+		message = '';
+
+		try {
+			// Reorder facets
+			const reorderResponse = await fetch('/api/facet-config/reorder', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ facets })
+			});
+
+			if (!reorderResponse.ok) {
+				throw new Error('Failed to save facet order');
+			}
+
+			// Update each facet
+			const updates = facets.map((facet) =>
+				fetch('/api/facet-config', {
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(facet)
+				})
+			);
+
+			await Promise.all(updates);
+
+			message = 'Facet configuration saved successfully!';
+			setTimeout(() => (message = ''), 3000);
+		} catch (error) {
+			message = error instanceof Error ? error.message : 'Error saving facet configuration';
+			console.error('Save error:', error);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function refreshCache(facetKey?: string) {
+		refreshingCache = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/facet-config/refresh-cache', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ facet_key: facetKey })
+			});
+
+			if (!response.ok) {
+				throw new Error('Failed to refresh cache');
+			}
+
+			const result = await response.json();
+			message = result.message;
+			setTimeout(() => (message = ''), 3000);
+		} catch (error) {
+			message = error instanceof Error ? error.message : 'Error refreshing cache';
+			console.error('Refresh cache error:', error);
+		} finally {
+			refreshingCache = false;
+		}
+	}
+
+	function editFacet(facet: any) {
+		editingFacet = { ...facet };
+	}
+
+	function cancelEditFacet() {
+		editingFacet = null;
+	}
+
+	async function saveEditedFacet() {
+		if (!editingFacet) return;
+
+		saving = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/facet-config', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(editingFacet)
+			});
+
+			if (!response.ok) {
+				throw new Error('Failed to save facet');
+			}
+
+			// Update local state
+			const index = facets.findIndex((f) => f.id === editingFacet.id);
+			if (index !== -1) {
+				facets[index] = { ...editingFacet };
+			}
+
+			editingFacet = null;
+			message = 'Facet saved successfully!';
+			setTimeout(() => (message = ''), 3000);
+		} catch (error) {
+			message = error instanceof Error ? error.message : 'Error saving facet';
+			console.error('Save error:', error);
+		} finally {
+			saving = false;
+		}
+	}
+
+	function createNewFacet() {
+		showNewFacetForm = true;
+		editingFacet = {
+			facet_key: '',
+			facet_label: '',
+			facet_description: '',
+			source_type: 'marc_field',
+			source_field: '',
+			source_subfield: '',
+			display_type: 'checkbox_list',
+			display_order: facets.length,
+			is_enabled: true,
+			is_collapsed_by_default: false,
+			show_count: true,
+			max_items: 10,
+			aggregation_method: 'distinct_values',
+			sort_by: 'count_desc',
+			filter_param_name: '',
+			multi_select: true,
+			cache_enabled: true,
+			public_visible: true,
+			staff_only: false
+		};
+	}
+
+	async function saveNewFacet() {
+		if (!editingFacet) return;
+
+		saving = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/facet-config', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(editingFacet)
+			});
+
+			if (!response.ok) {
+				throw new Error('Failed to create facet');
+			}
+
+			const result = await response.json();
+			facets = [...facets, result.facet];
+
+			editingFacet = null;
+			showNewFacetForm = false;
+			message = 'Facet created successfully!';
+			setTimeout(() => (message = ''), 3000);
+		} catch (error) {
+			message = error instanceof Error ? error.message : 'Error creating facet';
+			console.error('Create error:', error);
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function deleteFacet(facetId: string) {
+		if (!confirm('Are you sure you want to delete this facet?')) return;
+
+		saving = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/facet-config', {
+				method: 'DELETE',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id: facetId })
+			});
+
+			if (!response.ok) {
+				throw new Error('Failed to delete facet');
+			}
+
+			facets = facets.filter((f) => f.id !== facetId);
+			message = 'Facet deleted successfully!';
+			setTimeout(() => (message = ''), 3000);
+		} catch (error) {
+			message = error instanceof Error ? error.message : 'Error deleting facet';
+			console.error('Delete error:', error);
+		} finally {
+			saving = false;
+		}
 	}
 
 	async function saveConfiguration() {
@@ -304,69 +523,315 @@
 			</div>
 		{:else if activeTab === 'facets'}
 			<div class="facets-panel">
-				<section class="settings-section">
-					<h2>Faceted Search</h2>
-
-					<div class="form-group checkbox">
-						<label>
-							<input type="checkbox" bind:checked={config.enable_facets} />
-							Enable faceted search (filters)
-						</label>
+				<div class="panel-header">
+					<div class="header-content">
+						<div>
+							<h2>Facet Configuration</h2>
+							<p>Configure search facets and filters. Drag to reorder.</p>
+						</div>
+						<div class="header-actions">
+							<button
+								class="btn-secondary"
+								onclick={() => refreshCache()}
+								disabled={refreshingCache}
+							>
+								{refreshingCache ? 'Refreshing...' : 'Refresh All Caches'}
+							</button>
+							<button class="btn-primary" onclick={createNewFacet}>+ Create New Facet</button>
+						</div>
 					</div>
+				</div>
 
-					{#if config.enable_facets}
-						<div class="form-group">
-							<label for="max_facet_values">Maximum facet values to show</label>
-							<input
-								id="max_facet_values"
-								type="number"
-								min="3"
-								max="50"
-								bind:value={config.max_facet_values}
-							/>
-							<small>Number of options to show per facet group before "Show more"</small>
+				{#if showNewFacetForm && editingFacet}
+					<div class="facet-editor">
+						<div class="editor-header">
+							<h3>Create New Facet</h3>
+							<button class="btn-close" onclick={() => (showNewFacetForm = false)}>×</button>
 						</div>
 
-						<h3>Available Facets</h3>
+						<div class="editor-content">
+							<div class="form-grid">
+								<div class="form-group">
+									<label for="facet_key">Facet Key *</label>
+									<input
+										id="facet_key"
+										type="text"
+										bind:value={editingFacet.facet_key}
+										placeholder="e.g., subject, author, call_number_range"
+									/>
+									<small>Unique identifier (lowercase, underscores only)</small>
+								</div>
 
-						<div class="facet-toggles">
-							<div class="form-group checkbox">
-								<label>
-									<input type="checkbox" bind:checked={config.facet_material_types} />
-									Material Types (books, DVDs, etc.)
-								</label>
+								<div class="form-group">
+									<label for="facet_label">Display Label *</label>
+									<input
+										id="facet_label"
+										type="text"
+										bind:value={editingFacet.facet_label}
+										placeholder="e.g., Subject, Author, Call Number"
+									/>
+								</div>
+
+								<div class="form-group full-width">
+									<label for="facet_description">Description</label>
+									<input
+										id="facet_description"
+										type="text"
+										bind:value={editingFacet.facet_description}
+										placeholder="Help text for users"
+									/>
+								</div>
+
+								<div class="form-group">
+									<label for="source_type">Data Source Type *</label>
+									<select id="source_type" bind:value={editingFacet.source_type}>
+										<option value="database_column">Database Column</option>
+										<option value="marc_field">MARC Field</option>
+										<option value="items_field">Items Table Field</option>
+										<option value="computed">Computed</option>
+									</select>
+								</div>
+
+								<div class="form-group">
+									<label for="source_field">Source Field *</label>
+									<input
+										id="source_field"
+										type="text"
+										bind:value={editingFacet.source_field}
+										placeholder="e.g., material_type, publication_info, items.location"
+									/>
+								</div>
+
+								{#if editingFacet.source_type === 'marc_field'}
+									<div class="form-group">
+										<label for="source_subfield">MARC Subfield</label>
+										<input
+											id="source_subfield"
+											type="text"
+											bind:value={editingFacet.source_subfield}
+											placeholder="e.g., a, b, c"
+											maxlength="1"
+										/>
+									</div>
+								{/if}
+
+								<div class="form-group">
+									<label for="display_type">Display Type</label>
+									<select id="display_type" bind:value={editingFacet.display_type}>
+										<option value="checkbox_list">Checkbox List</option>
+										<option value="date_range">Date Range</option>
+										<option value="numeric_range">Numeric Range</option>
+										<option value="tag_cloud">Tag Cloud</option>
+									</select>
+								</div>
+
+								<div class="form-group">
+									<label for="aggregation_method">Aggregation Method</label>
+									<select id="aggregation_method" bind:value={editingFacet.aggregation_method}>
+										<option value="distinct_values">Distinct Values</option>
+										<option value="decade_buckets">Decade Buckets</option>
+										<option value="year_buckets">Year Buckets</option>
+										<option value="custom_ranges">Custom Ranges</option>
+									</select>
+								</div>
+
+								<div class="form-group">
+									<label for="sort_by">Sort By</label>
+									<select id="sort_by" bind:value={editingFacet.sort_by}>
+										<option value="count_desc">Count (Descending)</option>
+										<option value="count_asc">Count (Ascending)</option>
+										<option value="label_asc">Label (A-Z)</option>
+										<option value="label_desc">Label (Z-A)</option>
+										<option value="custom">Custom Order</option>
+									</select>
+								</div>
+
+								<div class="form-group">
+									<label for="max_items">Max Items to Display</label>
+									<input
+										id="max_items"
+										type="number"
+										min="3"
+										max="50"
+										bind:value={editingFacet.max_items}
+									/>
+								</div>
+
+								<div class="form-group">
+									<label for="filter_param">URL Parameter Name</label>
+									<input
+										id="filter_param"
+										type="text"
+										bind:value={editingFacet.filter_param_name}
+										placeholder="e.g., subjects, authors"
+									/>
+									<small>Name for URL query parameter</small>
+								</div>
+
+								<div class="form-group full-width">
+									<div class="checkbox-group">
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={editingFacet.is_enabled} />
+											Enabled
+										</label>
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={editingFacet.show_count} />
+											Show Count
+										</label>
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={editingFacet.multi_select} />
+											Allow Multiple Selection
+										</label>
+										<label class="checkbox">
+											<input
+												type="checkbox"
+												bind:checked={editingFacet.is_collapsed_by_default}
+											/>
+											Collapsed by Default
+										</label>
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={editingFacet.cache_enabled} />
+											Enable Caching
+										</label>
+									</div>
+								</div>
 							</div>
 
-							<div class="form-group checkbox">
-								<label>
-									<input type="checkbox" bind:checked={config.facet_languages} />
-									Languages
-								</label>
-							</div>
-
-							<div class="form-group checkbox">
-								<label>
-									<input type="checkbox" bind:checked={config.facet_publication_years} />
-									Publication Years
-								</label>
-							</div>
-
-							<div class="form-group checkbox">
-								<label>
-									<input type="checkbox" bind:checked={config.facet_locations} />
-									Locations
-								</label>
-							</div>
-
-							<div class="form-group checkbox">
-								<label>
-									<input type="checkbox" bind:checked={config.facet_availability} />
-									Availability (available / checked out)
-								</label>
+							<div class="editor-actions">
+								<button class="btn-primary" onclick={saveNewFacet} disabled={saving}>
+									{saving ? 'Creating...' : 'Create Facet'}
+								</button>
+								<button
+									class="btn-secondary"
+									onclick={() => {
+										showNewFacetForm = false;
+										editingFacet = null;
+									}}
+								>
+									Cancel
+								</button>
 							</div>
 						</div>
+					</div>
+				{/if}
+
+				<div class="facets-list">
+					{#if facets.length === 0}
+						<div class="empty-state">
+							<p>No facets configured yet.</p>
+							<button class="btn-primary" onclick={createNewFacet}>Create Your First Facet</button>
+						</div>
+					{:else}
+						{#each facets as facet, index (facet.id)}
+							<div
+								class="facet-item"
+								class:inactive={!facet.is_active || !facet.is_enabled}
+								draggable="true"
+								ondragstart={() => handleFacetDragStart(index)}
+								ondragover={(e) => handleFacetDragOver(e, index)}
+								ondragend={handleFacetDragEnd}
+							>
+								<div class="drag-handle">
+									<svg width="16" height="16" viewBox="0 0 16 16">
+										<path d="M5 3h6M5 8h6M5 13h6" stroke="currentColor" stroke-width="2" />
+									</svg>
+								</div>
+
+								<div class="facet-info">
+									<div class="facet-header">
+										<div class="facet-name">
+											<strong>{facet.facet_label}</strong>
+											<span class="facet-key">{facet.facet_key}</span>
+											{#if !facet.is_active}
+												<span class="badge badge-inactive">Deleted</span>
+											{:else if !facet.is_enabled}
+												<span class="badge badge-disabled">Disabled</span>
+											{:else}
+												<span class="badge badge-active">Active</span>
+											{/if}
+										</div>
+										<div class="facet-actions">
+											<button
+												class="btn-icon"
+												onclick={() => refreshCache(facet.facet_key)}
+												disabled={refreshingCache}
+												title="Refresh cache"
+											>
+												🔄
+											</button>
+											<button class="btn-icon" onclick={() => editFacet(facet)} title="Edit">
+												✏️
+											</button>
+											<button
+												class="btn-icon"
+												onclick={() => deleteFacet(facet.id)}
+												title="Delete"
+											>
+												🗑️
+											</button>
+										</div>
+									</div>
+
+									<div class="facet-details">
+										<div class="detail-item">
+											<span class="label">Source:</span>
+											<span class="value"
+												>{facet.source_type} - {facet.source_field}{facet.source_subfield
+													? `$${facet.source_subfield}`
+													: ''}</span
+											>
+										</div>
+										<div class="detail-item">
+											<span class="label">Type:</span>
+											<span class="value">{facet.display_type}</span>
+										</div>
+										<div class="detail-item">
+											<span class="label">Method:</span>
+											<span class="value">{facet.aggregation_method}</span>
+										</div>
+										<div class="detail-item">
+											<span class="label">Max Items:</span>
+											<span class="value">{facet.max_items}</span>
+										</div>
+									</div>
+
+									<div class="facet-controls">
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={facet.is_enabled} />
+											Enabled
+										</label>
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={facet.show_count} />
+											Show Count
+										</label>
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={facet.multi_select} />
+											Multi-select
+										</label>
+										<label class="checkbox">
+											<input type="checkbox" bind:checked={facet.is_collapsed_by_default} />
+											Collapsed by Default
+										</label>
+									</div>
+								</div>
+							</div>
+						{/each}
 					{/if}
-				</section>
+				</div>
+
+				<div class="form-actions">
+					<button class="btn-primary" onclick={saveFacets} disabled={saving}>
+						{saving ? 'Saving...' : 'Save Facet Configuration'}
+					</button>
+					<button
+						class="btn-secondary"
+						onclick={() => {
+							facets = [...data.facets];
+						}}
+					>
+						Reset
+					</button>
+				</div>
 			</div>
 		{/if}
 	</div>
@@ -624,6 +1089,227 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;
+	}
+
+	/* Facet Configuration Styles */
+	.header-content {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		margin-bottom: 2rem;
+	}
+
+	.header-actions {
+		display: flex;
+		gap: 1rem;
+	}
+
+	.facets-list {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		margin: 2rem 0;
+	}
+
+	.facet-item {
+		display: flex;
+		gap: 1rem;
+		padding: 1.5rem;
+		background: white;
+		border: 2px solid #e0e0e0;
+		border-radius: 8px;
+		cursor: move;
+		transition: all 0.2s;
+	}
+
+	.facet-item:hover {
+		border-color: #ccc;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	}
+
+	.facet-item.inactive {
+		opacity: 0.6;
+		background: #f5f5f5;
+	}
+
+	.facet-info {
+		flex: 1;
+	}
+
+	.facet-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 1rem;
+	}
+
+	.facet-name {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.facet-name strong {
+		font-size: 1.125rem;
+		color: #2c3e50;
+	}
+
+	.facet-actions {
+		display: flex;
+		gap: 0.5rem;
+	}
+
+	.btn-icon {
+		padding: 0.5rem;
+		background: none;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 1rem;
+		transition: all 0.2s;
+	}
+
+	.btn-icon:hover:not(:disabled) {
+		background: #f5f5f5;
+		border-color: #ccc;
+	}
+
+	.btn-icon:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.facet-details {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 1rem;
+		margin-bottom: 1rem;
+		padding: 1rem;
+		background: #f8f9fa;
+		border-radius: 4px;
+	}
+
+	.detail-item {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.detail-item .label {
+		font-size: 0.75rem;
+		color: #666;
+		text-transform: uppercase;
+		font-weight: 500;
+	}
+
+	.detail-item .value {
+		font-size: 0.875rem;
+		color: #333;
+		font-family: monospace;
+	}
+
+	.badge {
+		padding: 0.25rem 0.75rem;
+		border-radius: 12px;
+		font-size: 0.75rem;
+		font-weight: 500;
+		text-transform: uppercase;
+	}
+
+	.badge-active {
+		background: #d4edda;
+		color: #155724;
+	}
+
+	.badge-disabled {
+		background: #fff3cd;
+		color: #856404;
+	}
+
+	.badge-inactive {
+		background: #f8d7da;
+		color: #721c24;
+	}
+
+	.empty-state {
+		text-align: center;
+		padding: 3rem;
+		color: #666;
+	}
+
+	.empty-state p {
+		margin-bottom: 1rem;
+		font-size: 1.125rem;
+	}
+
+	/* Facet Editor */
+	.facet-editor {
+		background: white;
+		border: 2px solid #e73b42;
+		border-radius: 8px;
+		margin-bottom: 2rem;
+		overflow: hidden;
+	}
+
+	.editor-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 1.5rem;
+		background: #e73b42;
+		color: white;
+	}
+
+	.editor-header h3 {
+		margin: 0;
+		font-size: 1.25rem;
+	}
+
+	.btn-close {
+		background: none;
+		border: none;
+		color: white;
+		font-size: 2rem;
+		cursor: pointer;
+		padding: 0;
+		width: 2rem;
+		height: 2rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		line-height: 1;
+	}
+
+	.btn-close:hover {
+		opacity: 0.8;
+	}
+
+	.editor-content {
+		padding: 2rem;
+	}
+
+	.form-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1.5rem;
+		margin-bottom: 2rem;
+	}
+
+	.form-grid .full-width {
+		grid-column: 1 / -1;
+	}
+
+	.checkbox-group {
+		display: flex;
+		gap: 2rem;
+		flex-wrap: wrap;
+	}
+
+	.editor-actions {
+		display: flex;
+		gap: 1rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid #e0e0e0;
 	}
 
 	.form-actions {

--- a/src/routes/api/facet-config/+server.ts
+++ b/src/routes/api/facet-config/+server.ts
@@ -1,0 +1,154 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// GET - Fetch all facet configurations
+export const GET: RequestHandler = async ({ locals: { supabase, safeGetSession }, url }) => {
+	const { session } = await safeGetSession();
+
+	try {
+		// Check if we should include inactive facets (admin only)
+		const includeInactive = url.searchParams.get('include_inactive') === 'true' && session;
+
+		let query = supabase
+			.from('facet_configuration')
+			.select('*')
+			.order('display_order', { ascending: true });
+
+		// Filter by active status if not admin requesting all
+		if (!includeInactive) {
+			query = query.eq('is_enabled', true).eq('is_active', true);
+		}
+
+		const { data, error: queryError } = await query;
+
+		if (queryError) throw queryError;
+
+		return json({ facets: data || [] });
+	} catch (err) {
+		console.error('Error fetching facet configurations:', err);
+		return json(
+			{ error: 'Failed to fetch facet configurations' },
+			{ status: 500 }
+		);
+	}
+};
+
+// PUT - Update facet configuration (requires auth)
+export const PUT: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	try {
+		const config = await request.json();
+
+		// Validate required fields
+		if (!config.id) {
+			throw error(400, 'Facet ID is required');
+		}
+
+		// Update the configuration
+		const { data, error: updateError } = await supabase
+			.from('facet_configuration')
+			.update({
+				...config,
+				updated_by: session.user.id,
+				updated_at: new Date().toISOString()
+			})
+			.eq('id', config.id)
+			.select()
+			.single();
+
+		if (updateError) throw updateError;
+
+		return json({ success: true, facet: data });
+	} catch (err) {
+		console.error('Error updating facet configuration:', err);
+		if (err instanceof Error && 'status' in err) {
+			throw err;
+		}
+		return json(
+			{ error: 'Failed to update facet configuration' },
+			{ status: 500 }
+		);
+	}
+};
+
+// POST - Create new facet configuration (requires auth)
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	try {
+		const config = await request.json();
+
+		// Validate required fields
+		if (!config.facet_key || !config.facet_label || !config.source_type || !config.source_field) {
+			throw error(400, 'Missing required fields: facet_key, facet_label, source_type, source_field');
+		}
+
+		// Create the configuration
+		const { data, error: insertError } = await supabase
+			.from('facet_configuration')
+			.insert({
+				...config,
+				updated_by: session.user.id
+			})
+			.select()
+			.single();
+
+		if (insertError) throw insertError;
+
+		return json({ success: true, facet: data });
+	} catch (err) {
+		console.error('Error creating facet configuration:', err);
+		if (err instanceof Error && 'status' in err) {
+			throw err;
+		}
+		return json(
+			{ error: 'Failed to create facet configuration' },
+			{ status: 500 }
+		);
+	}
+};
+
+// DELETE - Delete facet configuration (requires auth)
+export const DELETE: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	try {
+		const { id } = await request.json();
+
+		if (!id) {
+			throw error(400, 'Facet ID is required');
+		}
+
+		// Soft delete by setting is_active to false
+		const { error: deleteError } = await supabase
+			.from('facet_configuration')
+			.update({ is_active: false, updated_by: session.user.id })
+			.eq('id', id);
+
+		if (deleteError) throw deleteError;
+
+		return json({ success: true });
+	} catch (err) {
+		console.error('Error deleting facet configuration:', err);
+		if (err instanceof Error && 'status' in err) {
+			throw err;
+		}
+		return json(
+			{ error: 'Failed to delete facet configuration' },
+			{ status: 500 }
+		);
+	}
+};

--- a/src/routes/api/facet-config/refresh-cache/+server.ts
+++ b/src/routes/api/facet-config/refresh-cache/+server.ts
@@ -1,0 +1,50 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// POST - Refresh facet cache (requires auth)
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	try {
+		const { facet_key } = await request.json();
+
+		if (facet_key) {
+			// Refresh cache for specific facet
+			const { data, error: rpcError } = await supabase.rpc('refresh_facet_cache', {
+				facet_key_param: facet_key
+			});
+
+			if (rpcError) throw rpcError;
+
+			return json({
+				success: true,
+				message: `Refreshed cache for facet: ${facet_key}`,
+				deleted_count: data
+			});
+		} else {
+			// Refresh all facet caches
+			const { data, error: rpcError } = await supabase.rpc('refresh_all_facet_caches');
+
+			if (rpcError) throw rpcError;
+
+			return json({
+				success: true,
+				message: 'Refreshed all facet caches',
+				deleted_count: data
+			});
+		}
+	} catch (err) {
+		console.error('Error refreshing facet cache:', err);
+		if (err instanceof Error && 'status' in err) {
+			throw err;
+		}
+		return json(
+			{ error: 'Failed to refresh facet cache' },
+			{ status: 500 }
+		);
+	}
+};

--- a/src/routes/api/facet-config/reorder/+server.ts
+++ b/src/routes/api/facet-config/reorder/+server.ts
@@ -1,0 +1,44 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// POST - Reorder facets (requires auth)
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	try {
+		const { facets } = await request.json();
+
+		if (!Array.isArray(facets)) {
+			throw error(400, 'Invalid facets array');
+		}
+
+		// Update display_order for each facet
+		const updates = facets.map((facet, index) =>
+			supabase
+				.from('facet_configuration')
+				.update({
+					display_order: index,
+					updated_by: session.user.id,
+					updated_at: new Date().toISOString()
+				})
+				.eq('id', facet.id)
+		);
+
+		await Promise.all(updates);
+
+		return json({ success: true });
+	} catch (err) {
+		console.error('Error reordering facets:', err);
+		if (err instanceof Error && 'status' in err) {
+			throw err;
+		}
+		return json(
+			{ error: 'Failed to reorder facets' },
+			{ status: 500 }
+		);
+	}
+};

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -639,7 +639,12 @@
 				<h2>Refine Results</h2>
 				<button class="mobile-close" onclick={toggleMobileFilters}>×</button>
 			</div>
-			<FacetSidebar facets={data.facets} currentFilters={data.query} onFilterChange={updateUrl} />
+			<FacetSidebar
+				facets={data.facets}
+				facetConfigs={data.facetConfigs}
+				currentFilters={data.query}
+				onFilterChange={updateUrl}
+			/>
 		</aside>
 
 		<!-- Results Area -->

--- a/src/routes/catalog/search/results/FacetSidebar.svelte
+++ b/src/routes/catalog/search/results/FacetSidebar.svelte
@@ -1,185 +1,128 @@
 <script lang="ts">
 	import type { FacetGroup } from './+page.server';
 	import type { SearchParams } from './+page.server';
+	import type { FacetConfig } from '$lib/utils/facets';
 
 	interface Props {
 		facets: FacetGroup;
+		facetConfigs: FacetConfig[];
 		currentFilters: SearchParams;
 		onFilterChange: (updates: Record<string, any>) => void;
 	}
 
-	let { facets, currentFilters, onFilterChange }: Props = $props();
+	let { facets, facetConfigs, currentFilters, onFilterChange }: Props = $props();
 
-	let expandedSections = $state({
-		material_types: true,
-		languages: true,
-		years: true,
-		availability: true,
-		locations: true
-	});
+	// Initialize expanded sections dynamically based on facet configs
+	let expandedSections = $state<Record<string, boolean>>(
+		Object.fromEntries(facetConfigs.map((config) => [config.facet_key, !config.is_collapsed_by_default]))
+	);
 
-	function toggleSection(section: keyof typeof expandedSections) {
+	function toggleSection(section: string) {
 		expandedSections[section] = !expandedSections[section];
 	}
 
-	function toggleFacet(facetType: string, value: string) {
-		const currentValues = getCurrentValues(facetType);
+	function toggleFacet(filterParamName: string, value: string) {
+		const currentValues = getCurrentValues(filterParamName);
 		const newValues = currentValues.includes(value)
 			? currentValues.filter((v) => v !== value)
 			: [...currentValues, value];
 
-		onFilterChange({ [facetType]: newValues });
+		onFilterChange({ [filterParamName]: newValues });
 	}
 
-	function getCurrentValues(facetType: string): string[] {
-		switch (facetType) {
-			case 'material_types':
-				return currentFilters.material_types || [];
-			case 'languages':
-				return currentFilters.languages || [];
-			case 'availability':
-				return currentFilters.availability || [];
-			case 'locations':
-				return currentFilters.locations || [];
-			default:
-				return [];
+	function getCurrentValues(filterParamName: string): string[] {
+		// Check if the filter exists in currentFilters
+		const filterValue = (currentFilters as any)[filterParamName];
+		if (Array.isArray(filterValue)) {
+			return filterValue;
 		}
+		return [];
 	}
 
-	function isSelected(facetType: string, value: string): boolean {
-		return getCurrentValues(facetType).includes(value);
+	function isSelected(filterParamName: string, value: string): boolean {
+		return getCurrentValues(filterParamName).includes(value);
+	}
+
+	// Get facet values for a specific facet key
+	function getFacetValues(facetKey: string) {
+		return facets[facetKey] || [];
 	}
 </script>
 
 <div class="facet-sidebar">
-	<!-- Material Type Facet -->
-	{#if facets.material_types.length > 0}
-		<div class="facet-group">
-			<button class="facet-header" onclick={() => toggleSection('material_types')}>
-				<h3>Material Type</h3>
-				<span class="toggle-icon">{expandedSections.material_types ? '−' : '+'}</span>
-			</button>
-			{#if expandedSections.material_types}
-				<div class="facet-list">
-					{#each facets.material_types as facet}
-						<label class="facet-item">
-							<input
-								type="checkbox"
-								checked={isSelected('material_types', facet.value)}
-								onchange={() => toggleFacet('material_types', facet.value)}
-							/>
-							<span class="facet-label">{facet.label}</span>
-							<span class="facet-count">{facet.count.toLocaleString()}</span>
-						</label>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	{/if}
-
-	<!-- Availability Facet -->
-	{#if facets.availability.length > 0}
-		<div class="facet-group">
-			<button class="facet-header" onclick={() => toggleSection('availability')}>
-				<h3>Availability</h3>
-				<span class="toggle-icon">{expandedSections.availability ? '−' : '+'}</span>
-			</button>
-			{#if expandedSections.availability}
-				<div class="facet-list">
-					{#each facets.availability as facet}
-						<label class="facet-item">
-							<input
-								type="checkbox"
-								checked={isSelected('availability', facet.value)}
-								onchange={() => toggleFacet('availability', facet.value)}
-							/>
-							<span class="facet-label">{facet.label}</span>
-							<span class="facet-count">{facet.count.toLocaleString()}</span>
-						</label>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	{/if}
-
-	<!-- Location Facet -->
-	{#if facets.locations.length > 0}
-		<div class="facet-group">
-			<button class="facet-header" onclick={() => toggleSection('locations')}>
-				<h3>Location</h3>
-				<span class="toggle-icon">{expandedSections.locations ? '−' : '+'}</span>
-			</button>
-			{#if expandedSections.locations}
-				<div class="facet-list">
-					{#each facets.locations as facet}
-						<label class="facet-item">
-							<input
-								type="checkbox"
-								checked={isSelected('locations', facet.value)}
-								onchange={() => toggleFacet('locations', facet.value)}
-							/>
-							<span class="facet-label">{facet.label}</span>
-							<span class="facet-count">{facet.count.toLocaleString()}</span>
-						</label>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	{/if}
-
-	<!-- Language Facet -->
-	{#if facets.languages.length > 0}
-		<div class="facet-group">
-			<button class="facet-header" onclick={() => toggleSection('languages')}>
-				<h3>Language</h3>
-				<span class="toggle-icon">{expandedSections.languages ? '−' : '+'}</span>
-			</button>
-			{#if expandedSections.languages}
-				<div class="facet-list">
-					{#each facets.languages as facet}
-						<label class="facet-item">
-							<input
-								type="checkbox"
-								checked={isSelected('languages', facet.value)}
-								onchange={() => toggleFacet('languages', facet.value)}
-							/>
-							<span class="facet-label">{facet.label}</span>
-							<span class="facet-count">{facet.count.toLocaleString()}</span>
-						</label>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	{/if}
-
-	<!-- Publication Year Facet -->
-	{#if facets.publication_years.length > 0}
-		<div class="facet-group">
-			<button class="facet-header" onclick={() => toggleSection('years')}>
-				<h3>Publication Year</h3>
-				<span class="toggle-icon">{expandedSections.years ? '−' : '+'}</span>
-			</button>
-			{#if expandedSections.years}
-				<div class="facet-list">
-					{#each facets.publication_years as facet}
-						<button
-							class="facet-year-button"
-							onclick={() => {
-								const decade = parseInt(facet.value);
-								onFilterChange({
-									year_from: String(decade),
-									year_to: String(decade + 9)
-								});
-							}}
-						>
-							<span class="facet-label">{facet.label}</span>
-							<span class="facet-count">{facet.count.toLocaleString()}</span>
-						</button>
-					{/each}
-				</div>
-			{/if}
-		</div>
-	{/if}
+	<!-- Dynamic Facets based on configuration -->
+	{#each facetConfigs as config (config.id)}
+		{@const facetValues = getFacetValues(config.facet_key)}
+		{#if facetValues.length > 0}
+			<div class="facet-group">
+				<button class="facet-header" onclick={() => toggleSection(config.facet_key)}>
+					<h3>{config.facet_label}</h3>
+					<span class="toggle-icon">{expandedSections[config.facet_key] ? '−' : '+'}</span>
+				</button>
+				{#if expandedSections[config.facet_key]}
+					<div class="facet-list">
+						{#if config.display_type === 'checkbox_list'}
+							{#each facetValues as facet}
+								<label class="facet-item">
+									<input
+										type="checkbox"
+										checked={isSelected(config.filter_param_name, facet.value)}
+										onchange={() => toggleFacet(config.filter_param_name, facet.value)}
+									/>
+									<span class="facet-label">{facet.label}</span>
+									{#if config.show_count}
+										<span class="facet-count">{facet.count.toLocaleString()}</span>
+									{/if}
+								</label>
+							{/each}
+						{:else if config.display_type === 'date_range'}
+							<!-- Date range slider or buttons -->
+							{#each facetValues as facet}
+								<button
+									class="facet-year-button"
+									onclick={() => {
+										if (config.aggregation_method === 'decade_buckets') {
+											const decade = parseInt(facet.value);
+											onFilterChange({
+												year_from: String(decade),
+												year_to: String(decade + 9)
+											});
+										} else if (config.aggregation_method === 'year_buckets') {
+											onFilterChange({
+												year_from: facet.value,
+												year_to: facet.value
+											});
+										}
+									}}
+								>
+									<span class="facet-label">{facet.label}</span>
+									{#if config.show_count}
+										<span class="facet-count">{facet.count.toLocaleString()}</span>
+									{/if}
+								</button>
+							{/each}
+						{:else if config.display_type === 'tag_cloud'}
+							<!-- Tag cloud view -->
+							<div class="tag-cloud">
+								{#each facetValues as facet}
+									<button
+										class="tag-item"
+										class:selected={isSelected(config.filter_param_name, facet.value)}
+										onclick={() => toggleFacet(config.filter_param_name, facet.value)}
+									>
+										{facet.label}
+										{#if config.show_count}
+											<span class="tag-count">({facet.count})</span>
+										{/if}
+									</button>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	{/each}
 </div>
 
 <style>
@@ -288,5 +231,43 @@
 
 	.facet-year-button .facet-label {
 		text-align: left;
+	}
+
+	/* Tag Cloud Styles */
+	.tag-cloud {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		padding: 0.5rem;
+	}
+
+	.tag-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.5rem 0.75rem;
+		background: #f8f9fa;
+		border: 1px solid #e0e0e0;
+		border-radius: 20px;
+		cursor: pointer;
+		font-size: 0.875rem;
+		color: #333;
+		transition: all 0.2s;
+	}
+
+	.tag-item:hover {
+		background: #e9ecef;
+		border-color: #ccc;
+	}
+
+	.tag-item.selected {
+		background: #e73b42;
+		color: white;
+		border-color: #e73b42;
+	}
+
+	.tag-count {
+		font-size: 0.75rem;
+		opacity: 0.8;
 	}
 </style>


### PR DESCRIPTION
Implemented a comprehensive faceted search configuration system that allows admins to create, configure, and manage search facets without code changes.

Key features:
- Database migration for facet configuration and caching tables
- Admin UI for facet management with drag-and-drop reordering
- Dynamic facet computation based on database configuration
- Support for multiple facet types: checkbox list, date range, tag cloud
- Configurable aggregation methods: distinct values, decade buckets, year buckets, custom ranges
- Custom facet builder for MARC fields, database columns, and items fields
- Facet value caching for improved performance
- Comprehensive facet configuration options (display, sorting, filtering)

Files added:
- migrations/018_faceted_search_configuration.sql: Database schema for facet config
- src/lib/utils/facets.ts: Dynamic facet computation utilities
- src/routes/api/facet-config/+server.ts: CRUD API for facet configurations
- src/routes/api/facet-config/reorder/+server.ts: Facet reordering API
- src/routes/api/facet-config/refresh-cache/+server.ts: Cache management API

Files modified:
- src/routes/admin/search-config/+page.server.ts: Load facet configurations
- src/routes/admin/search-config/+page.svelte: Enhanced UI with facet management tab
- src/routes/catalog/search/results/+page.server.ts: Use dynamic facet system
- src/routes/catalog/search/results/FacetSidebar.svelte: Support dynamic facets
- src/routes/catalog/search/results/+page.svelte: Pass facet configs to sidebar