### PR TITLE
Add patron self-service portal

### DIFF
--- a/migrations/019_patron_self_service.sql
+++ b/migrations/019_patron_self_service.sql
@@ -1,0 +1,272 @@
+-- Patron Self-Service Portal enhancements
+-- Adds PIN support, preferences, notifications, fines, and saved searches
+
+-- Enable pgcrypto for PIN hashing
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Extend patrons table with PIN storage and email verification tracking
+ALTER TABLE patrons
+  ADD COLUMN IF NOT EXISTS pin_hash TEXT,
+  ADD COLUMN IF NOT EXISTS pin_updated_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS email_verified BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN patrons.pin_hash IS 'Hashed PIN for card authentication (bcrypt via pgcrypto)';
+COMMENT ON COLUMN patrons.pin_updated_at IS 'Timestamp when PIN was last changed';
+COMMENT ON COLUMN patrons.email_verified IS 'Flag indicating patron has verified their email address';
+
+-- Add suspension and notification preferences to holds
+ALTER TABLE holds
+  ADD COLUMN IF NOT EXISTS suspended_until TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS suspension_reason TEXT,
+  ADD COLUMN IF NOT EXISTS notification_channels TEXT[] DEFAULT ARRAY['email'];
+
+COMMENT ON COLUMN holds.suspended_until IS 'Date until which the hold is paused/suspended';
+COMMENT ON COLUMN holds.notification_channels IS 'Preferred channels for hold notifications (email, sms)';
+
+-- Patron preferences table
+CREATE TABLE IF NOT EXISTS patron_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  patron_id UUID NOT NULL REFERENCES patrons(id) ON DELETE CASCADE,
+  email_opt_in BOOLEAN DEFAULT TRUE,
+  sms_opt_in BOOLEAN DEFAULT FALSE,
+  sms_number VARCHAR(50),
+  preferred_language VARCHAR(10) DEFAULT 'en',
+  default_pickup_location VARCHAR(255),
+  checkout_history_opt_in BOOLEAN DEFAULT FALSE,
+  digital_receipts BOOLEAN DEFAULT TRUE,
+  privacy_level VARCHAR(50) DEFAULT 'standard',
+  marketing_opt_out BOOLEAN DEFAULT TRUE,
+  notice_lead_time_days INTEGER DEFAULT 3,
+  notification_preferences JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_patron_preferences_unique ON patron_preferences(patron_id);
+
+-- Saved searches table
+CREATE TABLE IF NOT EXISTS saved_searches (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  patron_id UUID NOT NULL REFERENCES patrons(id) ON DELETE CASCADE,
+  name VARCHAR(255) NOT NULL,
+  query JSONB NOT NULL DEFAULT '{}'::jsonb,
+  last_run_at TIMESTAMPTZ,
+  last_result_count INTEGER,
+  send_email_alerts BOOLEAN DEFAULT FALSE,
+  alert_frequency VARCHAR(50) DEFAULT 'weekly',
+  is_active BOOLEAN DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_searches_patron ON saved_searches(patron_id);
+CREATE INDEX IF NOT EXISTS idx_saved_searches_active ON saved_searches(is_active);
+
+-- Patron notifications table
+CREATE TABLE IF NOT EXISTS patron_notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  patron_id UUID NOT NULL REFERENCES patrons(id) ON DELETE CASCADE,
+  type VARCHAR(100) NOT NULL,
+  channel VARCHAR(50) DEFAULT 'email',
+  status VARCHAR(50) DEFAULT 'queued',
+  title VARCHAR(255),
+  message TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  sent_at TIMESTAMPTZ,
+  read_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_patron_notifications_patron ON patron_notifications(patron_id);
+CREATE INDEX IF NOT EXISTS idx_patron_notifications_status ON patron_notifications(status);
+
+-- Patron fines and payments
+CREATE TABLE IF NOT EXISTS patron_fines (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  patron_id UUID NOT NULL REFERENCES patrons(id) ON DELETE CASCADE,
+  checkout_id UUID REFERENCES checkouts(id),
+  reason TEXT NOT NULL,
+  amount NUMERIC(10,2) NOT NULL,
+  balance NUMERIC(10,2) DEFAULT 0,
+  status VARCHAR(50) DEFAULT 'outstanding',
+  fine_date TIMESTAMPTZ DEFAULT NOW(),
+  due_date TIMESTAMPTZ,
+  resolved_at TIMESTAMPTZ,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_patron_fines_patron ON patron_fines(patron_id);
+CREATE INDEX IF NOT EXISTS idx_patron_fines_status ON patron_fines(status);
+
+CREATE TABLE IF NOT EXISTS patron_payments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  patron_id UUID NOT NULL REFERENCES patrons(id) ON DELETE CASCADE,
+  fine_id UUID REFERENCES patron_fines(id) ON DELETE SET NULL,
+  amount NUMERIC(10,2) NOT NULL,
+  method VARCHAR(50) DEFAULT 'online',
+  provider_reference VARCHAR(255),
+  status VARCHAR(50) DEFAULT 'pending',
+  processed_at TIMESTAMPTZ,
+  notes TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_patron_payments_patron ON patron_payments(patron_id);
+CREATE INDEX IF NOT EXISTS idx_patron_payments_fine ON patron_payments(fine_id);
+
+-- Utility function to refresh updated_at
+CREATE OR REPLACE FUNCTION refresh_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Triggers
+CREATE TRIGGER patron_preferences_updated_at
+  BEFORE UPDATE ON patron_preferences
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_updated_at();
+
+CREATE TRIGGER saved_searches_updated_at
+  BEFORE UPDATE ON saved_searches
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_updated_at();
+
+CREATE TRIGGER patron_notifications_updated_at
+  BEFORE UPDATE ON patron_notifications
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_updated_at();
+
+CREATE TRIGGER patron_fines_updated_at
+  BEFORE UPDATE ON patron_fines
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_updated_at();
+
+CREATE TRIGGER patron_payments_updated_at
+  BEFORE UPDATE ON patron_payments
+  FOR EACH ROW
+  EXECUTE FUNCTION refresh_updated_at();
+
+-- Security policies
+ALTER TABLE patron_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE saved_searches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE patron_notifications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE patron_fines ENABLE ROW LEVEL SECURITY;
+ALTER TABLE patron_payments ENABLE ROW LEVEL SECURITY;
+
+-- Patron preferences policies
+CREATE POLICY "Patrons manage their preferences" ON patron_preferences
+  FOR ALL TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()))
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+-- Saved searches policies
+CREATE POLICY "Patrons manage saved searches" ON saved_searches
+  FOR ALL TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()))
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+-- Notifications policies
+CREATE POLICY "Patrons view their notifications" ON patron_notifications
+  FOR SELECT TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+CREATE POLICY "System inserts notifications" ON patron_notifications
+  FOR INSERT TO authenticated
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+CREATE POLICY "Patrons update notification read status" ON patron_notifications
+  FOR UPDATE TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()))
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+-- Fines and payments policies
+CREATE POLICY "Patrons view their fines" ON patron_fines
+  FOR SELECT TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+CREATE POLICY "Patrons update their fines status" ON patron_fines
+  FOR UPDATE TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()))
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+CREATE POLICY "Patrons view their payments" ON patron_payments
+  FOR SELECT TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+CREATE POLICY "Patrons insert their payments" ON patron_payments
+  FOR INSERT TO authenticated
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+-- Allow patrons to renew their own checkouts
+CREATE POLICY "Patrons can renew their own checkouts" ON checkouts
+  FOR UPDATE TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()))
+  WITH CHECK (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+-- Allow patrons to manage their circulation history when opt-in is enabled
+CREATE POLICY "Patrons view their circulation history" ON circulation_history
+  FOR SELECT TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+CREATE POLICY "Patrons delete their circulation history" ON circulation_history
+  FOR DELETE TO authenticated
+  USING (patron_id IN (SELECT id FROM patrons WHERE user_id = auth.uid()));
+
+-- Helper functions for PIN workflows
+CREATE OR REPLACE FUNCTION set_patron_pin(target_patron UUID, new_pin TEXT)
+RETURNS TEXT AS $$
+DECLARE
+  hashed TEXT;
+  caller UUID := auth.uid();
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM patrons WHERE id = target_patron AND user_id = caller) THEN
+    RAISE EXCEPTION 'Caller may only update their own PIN';
+  END IF;
+
+  hashed := crypt(new_pin, gen_salt('bf'));
+  UPDATE patrons
+    SET pin_hash = hashed,
+        pin_updated_at = NOW()
+    WHERE id = target_patron
+    RETURNING pin_hash INTO hashed;
+  RETURN hashed;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+CREATE OR REPLACE FUNCTION patron_card_login(card_number TEXT, provided_pin TEXT)
+RETURNS TABLE(patron_id UUID, user_id UUID, email TEXT) AS $$
+DECLARE
+  patron_record patrons%ROWTYPE;
+BEGIN
+  SELECT * INTO patron_record FROM patrons WHERE barcode = card_number;
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF patron_record.pin_hash IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF patron_record.pin_hash = crypt(provided_pin, patron_record.pin_hash) THEN
+    RETURN QUERY SELECT patron_record.id, patron_record.user_id, patron_record.email;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+GRANT EXECUTE ON FUNCTION set_patron_pin TO authenticated;
+GRANT EXECUTE ON FUNCTION patron_card_login TO anon, authenticated;
+
+-- Seed preferences for existing patrons
+INSERT INTO patron_preferences (patron_id)
+SELECT id FROM patrons
+ON CONFLICT (patron_id) DO NOTHING;
+
+-- Ensure balances default to amount when missing
+UPDATE patron_fines SET balance = amount WHERE balance = 0;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />
+
+declare module '$env/static/public' {
+  export const PUBLIC_SUPABASE_URL: string;
+  export const PUBLIC_SUPABASE_ANON_KEY: string;
+}

--- a/src/routes/api/authorities/loc/+server.ts
+++ b/src/routes/api/authorities/loc/+server.ts
@@ -208,7 +208,7 @@ async function fetchLocAuthorityDetails(uri: string): Promise<LocAuthority | nul
 		const response = await fetch(`${uri}.json`);
 
 		if (!response.ok) {
-			throw new Error(`LoC fetch error: ${response.statusStatus}`);
+			throw new Error(`LoC fetch error: ${response.status}`);
 		}
 
 		const data = await response.json();

--- a/src/routes/api/covers/bulk/+server.ts
+++ b/src/routes/api/covers/bulk/+server.ts
@@ -212,7 +212,8 @@ export const POST: RequestHandler = async ({ request, locals: { supabase, safeGe
 
 				try {
 					// Fetch cover using the fetch API
-					const fetchResponse = await fetch(`${url.origin}/api/covers/fetch`, {
+					const requestUrl = new URL(request.url);
+					const fetchResponse = await fetch(`${requestUrl.origin}/api/covers/fetch`, {
 						method: 'POST',
 						headers: {
 							'Content-Type': 'application/json',

--- a/src/routes/my-account/+layout.server.ts
+++ b/src/routes/my-account/+layout.server.ts
@@ -1,0 +1,35 @@
+import { redirect } from '@sveltejs/kit';
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals, url }) => {
+  if (url.pathname.startsWith('/my-account/login')) {
+    return { patron: null, isAuthPage: true };
+  }
+
+  const { session } = await locals.safeGetSession();
+
+  if (!session) {
+    throw redirect(303, `/my-account/login?redirect=${encodeURIComponent(url.pathname)}`);
+  }
+
+  const { data: patron, error: patronError } = await locals.supabase
+    .from('patrons')
+    .select(
+      `
+        *,
+        patron_type:patron_types(*),
+        preferences:patron_preferences(*)
+      `
+    )
+    .eq('user_id', session.user.id)
+    .single();
+
+  if (patronError) {
+    throw redirect(303, '/my-account/login');
+  }
+
+  return {
+    patron,
+    isAuthPage: false,
+  };
+};

--- a/src/routes/my-account/+layout.svelte
+++ b/src/routes/my-account/+layout.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { supabase } from '$lib/supabase';
+  import type { LayoutData } from './$types';
+
+  let { data }: { data: LayoutData } = $props();
+
+  const navLinks = [
+    { href: '/my-account', label: 'Dashboard' },
+    { href: '/my-account/checkouts', label: 'Checkouts' },
+    { href: '/my-account/history', label: 'History' },
+    { href: '/my-account/holds', label: 'Holds' },
+    { href: '/my-account/fines', label: 'Fines & Fees' },
+    { href: '/my-account/saved-searches', label: 'Saved Searches' },
+    { href: '/my-account/settings', label: 'Settings' },
+  ];
+
+  async function handleLogout() {
+    await supabase.auth.signOut();
+    window.location.href = '/my-account/login';
+  }
+  const isAuthPage = data.isAuthPage;
+</script>
+
+{#if isAuthPage}
+  <slot />
+{:else}
+  <div class="account-shell">
+    <aside class="sidebar">
+      <div class="patron-meta">
+        <p class="patron-name">{data.patron.first_name} {data.patron.last_name}</p>
+        <p class="patron-type">{data.patron.patron_type?.name ?? 'Patron'}</p>
+        {#if data.patron.expiration_date}
+          <p class="meta-line">Expires {new Date(data.patron.expiration_date).toLocaleDateString()}</p>
+        {/if}
+      </div>
+
+      <nav>
+        {#each navLinks as link}
+          <a class:active={$page.url.pathname === link.href} href={link.href}>
+            {link.label}
+          </a>
+        {/each}
+      </nav>
+
+      <button class="logout" onclick={handleLogout}>Logout</button>
+    </aside>
+
+    <main class="content">
+      <slot />
+    </main>
+  </div>
+{/if}
+
+<style>
+  .account-shell {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    min-height: 100vh;
+    background: #f5f5f5;
+  }
+
+  .sidebar {
+    background: #fff;
+    border-right: 1px solid #eee;
+    padding: 2rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .patron-meta {
+    background: #fdf4f4;
+    border: 1px solid #f4d3d6;
+    border-radius: 8px;
+    padding: 1rem;
+  }
+
+  .patron-name {
+    margin: 0;
+    font-weight: 700;
+    color: #2c3e50;
+  }
+
+  .patron-type,
+  .meta-line {
+    margin: 0.25rem 0 0 0;
+    color: #666;
+    font-size: 0.9rem;
+  }
+
+  nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  nav a {
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    text-decoration: none;
+    color: #2c3e50;
+    font-weight: 500;
+    border: 1px solid transparent;
+  }
+
+  nav a:hover,
+  nav a.active {
+    border-color: #e73b42;
+    color: #e73b42;
+    background: #fff5f5;
+  }
+
+  .logout {
+    margin-top: auto;
+    border: 1px solid #f1c7c9;
+    background: #fff;
+    color: #e73b42;
+    border-radius: 6px;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .logout:hover {
+    background: #fff0f0;
+  }
+
+  .content {
+    padding: 2rem;
+  }
+
+  @media (max-width: 960px) {
+    .account-shell {
+      grid-template-columns: 1fr;
+    }
+
+    .sidebar {
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      border-right: none;
+      border-bottom: 1px solid #eee;
+      flex-direction: row;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    nav {
+      flex-direction: row;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      padding: 0.5rem 0.75rem;
+    }
+
+    .patron-meta {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/routes/my-account/+page.server.ts
+++ b/src/routes/my-account/+page.server.ts
@@ -1,0 +1,93 @@
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ locals, parent }) => {
+  const { patron } = await parent();
+
+  const supabase = locals.supabase;
+
+  const [{ data: checkoutData }, { data: holdData }, { data: fineData }, { data: notificationData }, { data: listData }] =
+    await Promise.all([
+      supabase
+        .from('checkouts')
+        .select(
+          `
+          id,
+          due_date,
+          renewal_count,
+          status,
+          checkout_date,
+          item:items (
+            id,
+            call_number,
+            marc_record_id,
+            marc_record:marc_records (
+              id,
+              title_statement,
+              main_entry_personal_name,
+              material_type
+            )
+          )
+        `
+        )
+        .eq('patron_id', patron.id)
+        .in('status', ['checked_out', 'overdue']),
+      supabase
+        .from('holds')
+        .select(
+          `
+          id,
+          status,
+          hold_date,
+          queue_position,
+          pickup_location,
+          suspended_until,
+          marc_record:marc_records (
+            id,
+            title_statement,
+            main_entry_personal_name
+          )
+        `
+        )
+        .eq('patron_id', patron.id)
+        .in('status', ['placed', 'in_transit', 'available', 'picked_up']),
+      supabase
+        .from('patron_fines')
+        .select('id, reason, amount, balance, status')
+        .eq('patron_id', patron.id),
+      supabase
+        .from('patron_notifications')
+        .select('*')
+        .eq('patron_id', patron.id)
+        .order('created_at', { ascending: false })
+        .limit(6),
+      supabase
+        .from('reading_lists')
+        .select('id, name, is_public, created_at')
+        .eq('patron_id', patron.id)
+        .order('updated_at', { ascending: false })
+        .limit(3),
+    ]);
+
+  const checkouts = checkoutData ?? [];
+  const holds = holdData ?? [];
+  const fines = fineData ?? [];
+  const notifications = notificationData ?? [];
+  const readingLists = listData ?? [];
+
+  const totalBalance =
+    fines.reduce((sum, fine) => sum + Number(fine.balance ?? fine.amount ?? 0), 0) ?? 0;
+
+  return {
+    patron,
+    stats: {
+      checkouts: checkouts.length,
+      overdue: checkouts.filter((c) => c.status === 'overdue').length,
+      holds: holds.length,
+      fines: totalBalance,
+    },
+    notifications,
+    readingLists,
+    holds,
+    checkouts,
+  };
+};

--- a/src/routes/my-account/checkouts/+page.server.ts
+++ b/src/routes/my-account/checkouts/+page.server.ts
@@ -1,0 +1,186 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+const ACTIVE_STATUSES = ['checked_out', 'overdue'];
+
+async function requirePatron(locals: App.Locals) {
+  const { session } = await locals.safeGetSession();
+  if (!session) throw redirect(303, '/my-account/login');
+
+  const { data: patron } = await locals.supabase
+    .from('patrons')
+    .select('*, patron_type:patron_types(*)')
+    .eq('user_id', session.user.id)
+    .single();
+
+  if (!patron) throw redirect(303, '/my-account/login');
+  return patron;
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const patron = await requirePatron(locals);
+
+  const { data: checkouts } = await locals.supabase
+    .from('checkouts')
+    .select(
+      `
+      id,
+      patron_id,
+      checkout_date,
+      due_date,
+      renewal_count,
+      status,
+      item:items (
+        id,
+        call_number,
+        barcode,
+        marc_record_id,
+        marc_record:marc_records (
+          id,
+          title_statement,
+          main_entry_personal_name,
+          material_type
+        )
+      )
+    `
+    )
+    .eq('patron_id', patron.id)
+    .in('status', ACTIVE_STATUSES)
+    .order('due_date', { ascending: true });
+
+  const normalized =
+    checkouts?.map((checkout) => ({
+      ...checkout,
+      item: Array.isArray(checkout.item) ? checkout.item[0] : checkout.item,
+    })) ?? [];
+
+  return {
+    checkouts: normalized as any[],
+    patronType: patron.patron_type as any,
+  };
+};
+
+export const actions: Actions = {
+  renew: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const checkoutId = form.get('checkoutId') as string;
+
+    const { data: checkout } = await locals.supabase
+      .from('checkouts')
+      .select(
+        `
+        id,
+        patron_id,
+        due_date,
+        renewal_count,
+        status,
+        item:items (
+          id,
+          marc_record_id
+        )
+      `
+      )
+      .eq('id', checkoutId)
+      .eq('patron_id', patron.id)
+      .single();
+
+    if (!checkout) {
+      return fail(400, { message: 'Checkout not found' });
+    }
+
+    const item = Array.isArray(checkout.item) ? checkout.item[0] : checkout.item;
+
+    if (!ACTIVE_STATUSES.includes(checkout.status)) {
+      return fail(400, { message: 'This item cannot be renewed' });
+    }
+
+    if (checkout.renewal_count >= patron.patron_type.max_renewals) {
+      return fail(400, { message: 'Renewal limit reached' });
+    }
+
+    const { data: holdBlock } = await locals.supabase
+      .from('holds')
+      .select('id')
+      .eq('marc_record_id', item.marc_record_id)
+      .in('status', ['placed', 'in_transit'])
+      .limit(1);
+
+    if (holdBlock && holdBlock.length > 0) {
+      return fail(400, { message: 'Cannot renew: there is a hold on this title' });
+    }
+
+    const loanDays = patron.patron_type.default_loan_period_days ?? 14;
+    const newDue = new Date();
+    newDue.setDate(newDue.getDate() + loanDays);
+
+    const { error: updateError } = await locals.supabase
+      .from('checkouts')
+      .update({
+        due_date: newDue.toISOString(),
+        renewal_count: checkout.renewal_count + 1,
+        last_renewal_date: new Date().toISOString(),
+      })
+      .eq('id', checkout.id);
+
+    if (updateError) {
+      return fail(500, { message: 'Failed to renew item' });
+    }
+
+    throw redirect(303, '/my-account/checkouts?message=renewed');
+  },
+
+  renew_all: async ({ locals }) => {
+    const patron = await requirePatron(locals);
+
+    const { data: checkouts } = await locals.supabase
+      .from('checkouts')
+      .select(
+        `
+        id,
+        due_date,
+        renewal_count,
+        status,
+        item:items (
+          id,
+          marc_record_id
+        )
+      `
+      )
+      .eq('patron_id', patron.id)
+      .in('status', ACTIVE_STATUSES);
+
+    if (!checkouts || checkouts.length === 0) {
+      return fail(400, { message: 'No items available to renew' });
+    }
+
+    const loanDays = patron.patron_type.default_loan_period_days ?? 14;
+    const newDue = new Date();
+    newDue.setDate(newDue.getDate() + loanDays);
+
+    for (const checkout of checkouts) {
+      const item = Array.isArray(checkout.item) ? checkout.item[0] : checkout.item;
+      if (checkout.renewal_count >= patron.patron_type.max_renewals) continue;
+
+      const { data: holdBlock } = await locals.supabase
+        .from('holds')
+        .select('id')
+        .eq('marc_record_id', item.marc_record_id)
+        .in('status', ['placed', 'in_transit'])
+        .limit(1);
+
+      if (holdBlock && holdBlock.length > 0) continue;
+
+      await locals.supabase
+        .from('checkouts')
+        .update({
+          due_date: newDue.toISOString(),
+          renewal_count: checkout.renewal_count + 1,
+          last_renewal_date: new Date().toISOString(),
+        })
+        .eq('id', checkout.id);
+    }
+
+    throw redirect(303, '/my-account/checkouts?message=renewed_all');
+  },
+};

--- a/src/routes/my-account/checkouts/+page.svelte
+++ b/src/routes/my-account/checkouts/+page.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+  import BookCover from '$lib/components/BookCover.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+  const checkouts = data.checkouts as any[];
+
+  let message = $state('');
+
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const info = params.get('message');
+    if (info === 'renewed') message = 'Item renewed successfully';
+    if (info === 'renewed_all') message = 'Eligible items were renewed';
+  }
+
+  function daysUntil(dateString: string) {
+    const due = new Date(dateString);
+    return Math.ceil((due.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+  }
+
+  function printList() {
+    window.print();
+  }
+</script>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">Current loans</p>
+      <h1>Checkouts</h1>
+      <p class="muted">Renew eligible items, download your list, and watch due dates.</p>
+    </div>
+    <div class="actions">
+      <form method="post" action="?/renew_all">
+        <button type="submit" class="btn secondary">Renew all</button>
+      </form>
+      <button class="btn ghost" onclick={printList}>Download (print/PDF)</button>
+    </div>
+  </header>
+
+  {#if message}
+    <div class="toast success">{message}</div>
+  {/if}
+
+  <p class="muted small">
+    Renewal limit: {data.patronType.max_renewals} · Loan period: {data.patronType.default_loan_period_days} days
+  </p>
+
+  {#if checkouts.length === 0}
+    <div class="card">
+      <p class="muted">No active checkouts. Visit the catalog to borrow an item.</p>
+      <a class="btn primary" href="/catalog">Browse catalog</a>
+    </div>
+  {:else}
+    <div class="checkout-grid">
+      {#each checkouts as checkout}
+        <article class="card checkout">
+          <BookCover
+            recordId={checkout.item.marc_record?.id}
+            title={checkout.item.marc_record?.title_statement?.a}
+            author={checkout.item.marc_record?.main_entry_personal_name?.a}
+            size="medium"
+          />
+          <div class="meta">
+            <h2>
+              <a href={`/catalog/record/${checkout.item.marc_record?.id ?? checkout.item.id}`}>
+                {checkout.item.marc_record?.title_statement?.a ?? 'Untitled'}
+              </a>
+            </h2>
+            <p class="muted">
+              {checkout.item.marc_record?.main_entry_personal_name?.a ?? 'Unknown'}
+            </p>
+            <p class="muted">Barcode: {checkout.item.barcode}</p>
+            <div class="tags">
+              <span class="pill">Due {new Date(checkout.due_date).toLocaleDateString()}</span>
+              <span class="pill subtle">Renewals {checkout.renewal_count}/{data.patronType.max_renewals}</span>
+              {#if daysUntil(checkout.due_date) <= 3 && checkout.status !== 'overdue'}
+                <span class="pill warn">Due soon</span>
+              {/if}
+              {#if checkout.status === 'overdue'}
+                <span class="pill danger">Overdue</span>
+              {/if}
+            </div>
+          </div>
+          <form method="post" action="?/renew">
+            <input type="hidden" name="checkoutId" value={checkout.id} />
+            <button
+              type="submit"
+              class="btn primary"
+              disabled={checkout.renewal_count >= data.patronType.max_renewals || checkout.status === 'overdue'}
+            >
+              {checkout.renewal_count >= data.patronType.max_renewals ? 'Maxed out' : 'Renew'}
+            </button>
+          </form>
+        </article>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: #e73b42;
+    margin: 0 0 0.25rem 0;
+  }
+
+  h1 {
+    margin: 0;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  .btn {
+    border: 1px solid #e5e7eb;
+    padding: 0.65rem 1rem;
+    border-radius: 8px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .btn.primary {
+    background: #e73b42;
+    color: #fff;
+    border-color: #e73b42;
+  }
+
+  .btn.secondary {
+    background: #fff;
+  }
+
+  .btn.ghost {
+    background: #f9fafb;
+  }
+
+  .muted {
+    color: #6b7280;
+    margin: 0.25rem 0;
+  }
+
+  .small {
+    font-size: 0.9rem;
+  }
+
+  .card {
+    background: #fff;
+    border-radius: 12px;
+    border: 1px solid #f0f0f0;
+    padding: 1rem;
+  }
+
+  .checkout-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .checkout {
+    display: grid;
+    grid-template-columns: 120px 1fr 150px;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .meta h2 {
+    margin: 0;
+  }
+
+  .meta a {
+    text-decoration: none;
+    color: #1f2933;
+  }
+
+  .meta a:hover {
+    color: #e73b42;
+  }
+
+  .tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.35rem;
+  }
+
+  .pill {
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: #3730a3;
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+
+  .pill.subtle {
+    background: #f9fafb;
+    color: #4b5563;
+  }
+
+  .pill.warn {
+    background: #fff7ed;
+    color: #c05621;
+  }
+
+  .pill.danger {
+    background: #fff5f5;
+    color: #e73b42;
+  }
+
+  .toast {
+    border-radius: 8px;
+    padding: 0.85rem 1rem;
+    font-weight: 600;
+  }
+
+  .toast.success {
+    background: #e6f4ea;
+    border: 1px solid #c4eed2;
+    color: #15803d;
+  }
+
+  @media (max-width: 900px) {
+    .checkout {
+      grid-template-columns: 100px 1fr;
+      grid-template-rows: auto auto;
+    }
+
+    .checkout form {
+      grid-column: span 2;
+      justify-self: flex-start;
+    }
+  }
+</style>

--- a/src/routes/my-account/fines/+page.server.ts
+++ b/src/routes/my-account/fines/+page.server.ts
@@ -1,0 +1,66 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+async function requirePatron(locals: App.Locals) {
+  const { session } = await locals.safeGetSession();
+  if (!session) throw redirect(303, '/my-account/login');
+
+  const { data: patron } = await locals.supabase.from('patrons').select('id').eq('user_id', session.user.id).single();
+  if (!patron) throw redirect(303, '/my-account/login');
+  return patron;
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const patron = await requirePatron(locals);
+
+  const [{ data: fines }, { data: payments }] = await Promise.all([
+    locals.supabase
+      .from('patron_fines')
+      .select('*')
+      .eq('patron_id', patron.id)
+      .order('fine_date', { ascending: false }),
+    locals.supabase
+      .from('patron_payments')
+      .select('*')
+      .eq('patron_id', patron.id)
+      .order('created_at', { ascending: false }),
+  ]);
+
+  const totalBalance =
+    (fines ?? []).reduce((sum, fine) => sum + Number(fine.balance ?? fine.amount ?? 0), 0) ?? 0;
+
+  return {
+    fines: fines ?? [],
+    payments: payments ?? [],
+    totalBalance,
+  };
+};
+
+export const actions: Actions = {
+  pay: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const amount = Number(form.get('amount') ?? 0);
+    const fineId = form.get('fineId') as string | null;
+    const method = (form.get('method') as string) || 'online';
+
+    if (amount <= 0) {
+      return fail(400, { message: 'Payment amount must be greater than zero' });
+    }
+
+    const { error } = await locals.supabase.from('patron_payments').insert({
+      patron_id: patron.id,
+      fine_id: fineId,
+      amount,
+      method,
+      status: 'pending',
+      metadata: { origin: 'self_service' },
+    });
+
+    if (error) {
+      return fail(500, { message: 'Unable to record payment' });
+    }
+
+    throw redirect(303, '/my-account/fines?payment=1');
+  },
+};

--- a/src/routes/my-account/fines/+page.svelte
+++ b/src/routes/my-account/fines/+page.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  let amount = $state('');
+  let selectedFine = $state<string | null>(null);
+</script>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">Fees & Balances</p>
+      <h1>Fines</h1>
+      <p class="muted">See itemized charges, review payment history, and pay online.</p>
+    </div>
+    <div class="badge">Total Balance: ${data.totalBalance.toFixed(2)}</div>
+  </header>
+
+  <section class="grid two-col">
+    <div class="card">
+      <div class="section-header">
+        <h2>Outstanding fines</h2>
+      </div>
+      {#if data.fines.length === 0}
+        <p class="muted">No fines at this time.</p>
+      {:else}
+        <ul class="list">
+          {#each data.fines as fine}
+            <li class="item">
+              <div>
+                <p class="title">{fine.reason}</p>
+                <p class="muted">
+                  {new Date(fine.fine_date).toLocaleDateString()} · Status: {fine.status}
+                </p>
+              </div>
+              <div class="amount">${Number(fine.balance ?? fine.amount).toFixed(2)}</div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+
+    <div class="card">
+      <div class="section-header">
+        <h2>Make a payment</h2>
+      </div>
+      <form method="post" action="?/pay" class="form">
+        <label>
+          Apply to fine (optional)
+          <select bind:value={selectedFine}>
+            <option value="">Any</option>
+            {#each data.fines as fine}
+              <option value={fine.id}>{fine.reason} (${Number(fine.balance ?? fine.amount).toFixed(2)})</option>
+            {/each}
+          </select>
+        </label>
+        <label>
+          Amount
+          <input type="number" min="0" step="0.01" name="amount" bind:value={amount} required />
+        </label>
+        <label>
+          Method
+          <select name="method">
+            <option value="online">Online</option>
+            <option value="cash">Cash at desk</option>
+          </select>
+        </label>
+        <input type="hidden" name="fineId" value={selectedFine ?? ''} />
+        <button type="submit" class="btn primary">Submit payment</button>
+        <p class="muted small">Payments are recorded and routed to the configured provider.</p>
+      </form>
+    </div>
+  </section>
+
+  <section class="card">
+    <div class="section-header">
+      <h2>Payment history</h2>
+    </div>
+    {#if data.payments.length === 0}
+      <p class="muted">No payments recorded.</p>
+    {:else}
+      <ul class="list">
+        {#each data.payments as payment}
+          <li class="item">
+            <div>
+              <p class="title">Payment {payment.id.slice(0, 8)}</p>
+              <p class="muted">
+                {payment.method} · {new Date(payment.created_at).toLocaleString()} · {payment.status}
+              </p>
+            </div>
+            <div class="amount">${Number(payment.amount).toFixed(2)}</div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: #e73b42;
+    margin: 0 0 0.25rem 0;
+  }
+
+  .muted {
+    color: #6b7280;
+    margin: 0.25rem 0;
+  }
+
+  .badge {
+    background: #fff5f5;
+    color: #e73b42;
+    border: 1px solid #f4d3d6;
+    padding: 0.65rem 0.9rem;
+    border-radius: 10px;
+    font-weight: 700;
+  }
+
+  .grid {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .two-col {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+
+  .card {
+    background: #fff;
+    border: 1px solid #f0f0f0;
+    border-radius: 12px;
+    padding: 1rem;
+  }
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  }
+
+  .list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .item {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.75rem;
+    border: 1px solid #f4f4f5;
+    border-radius: 10px;
+  }
+
+  .title {
+    margin: 0;
+    font-weight: 700;
+    color: #1f2933;
+  }
+
+  .amount {
+    font-weight: 700;
+    color: #e73b42;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: 600;
+  }
+
+  input,
+  select {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 0.65rem;
+  }
+
+  .btn {
+    border: 1px solid #e5e7eb;
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: 700;
+  }
+
+  .btn.primary {
+    background: #e73b42;
+    color: #fff;
+    border-color: #e73b42;
+  }
+
+  .small {
+    font-size: 0.9rem;
+  }
+</style>

--- a/src/routes/my-account/history/+page.server.ts
+++ b/src/routes/my-account/history/+page.server.ts
@@ -1,0 +1,127 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+async function requirePatron(locals: App.Locals) {
+  const { session } = await locals.safeGetSession();
+  if (!session) throw redirect(303, '/my-account/login');
+
+  const { data: patron } = await locals.supabase
+    .from('patrons')
+    .select('*, preferences:patron_preferences(*)')
+    .eq('user_id', session.user.id)
+    .single();
+
+  if (!patron) throw redirect(303, '/my-account/login');
+  return patron;
+}
+
+export const load: PageServerLoad = async ({ locals, url }) => {
+  const patron = await requirePatron(locals);
+  const supabase = locals.supabase;
+
+  const start = url.searchParams.get('start');
+  const end = url.searchParams.get('end');
+  const material = url.searchParams.get('material');
+  const search = url.searchParams.get('search');
+
+  if (!patron.preferences?.checkout_history_opt_in) {
+    return {
+      optedIn: false,
+      history: [],
+    };
+  }
+
+  const { data: history } = await supabase
+    .from('circulation_history')
+    .select(
+      `
+      id,
+      action,
+      action_date,
+      item:items (
+        id,
+        barcode,
+        marc_record_id,
+        marc_record:marc_records (
+          id,
+          title_statement,
+          main_entry_personal_name,
+          material_type
+        )
+      )
+    `
+    )
+    .eq('patron_id', patron.id)
+    .order('action_date', { ascending: false })
+    .limit(200);
+
+  const rows = (history ?? []) as any[];
+
+  const filtered = rows.filter((entry) => {
+    const matchesMaterial = material
+      ? entry.item && !Array.isArray(entry.item.marc_record)
+        ? entry.item.marc_record?.material_type === material
+        : false
+      : true;
+    const matchesSearch = search
+      ? (() => {
+          const record = Array.isArray(entry.item?.marc_record)
+            ? entry.item?.marc_record?.[0]
+            : entry.item?.marc_record;
+          const title = record?.title_statement?.a?.toLowerCase() ?? '';
+          const author = record?.main_entry_personal_name?.a?.toLowerCase() ?? '';
+          return title.includes(search.toLowerCase()) || author.includes(search.toLowerCase());
+        })()
+      : true;
+    const actionDate = new Date(entry.action_date);
+    const matchesStart = start ? actionDate >= new Date(start) : true;
+    const matchesEnd = end ? actionDate <= new Date(end) : true;
+    return matchesMaterial && matchesSearch && matchesStart && matchesEnd;
+  });
+
+  return {
+    optedIn: true,
+    history: filtered.map((entry) => {
+      const item = entry.item && Array.isArray(entry.item) ? entry.item[0] : entry.item;
+      const marcRecord =
+        item && item.marc_record
+          ? Array.isArray(item.marc_record)
+            ? item.marc_record[0]
+            : item.marc_record
+          : undefined;
+      return { ...entry, item, marcRecord };
+    }),
+  };
+};
+
+export const actions: Actions = {
+  toggle_opt_in: async ({ locals }) => {
+    const patron = await requirePatron(locals);
+    const desired = !patron.preferences?.checkout_history_opt_in;
+
+    const { error } = await locals.supabase
+      .from('patron_preferences')
+      .update({ checkout_history_opt_in: desired })
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Could not update preference' });
+    }
+
+    throw redirect(303, '/my-account/history');
+  },
+  clear_history: async ({ locals }) => {
+    const patron = await requirePatron(locals);
+
+    const { error } = await locals.supabase
+      .from('circulation_history')
+      .delete()
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to clear history' });
+    }
+
+    throw redirect(303, '/my-account/history');
+  },
+};

--- a/src/routes/my-account/history/+page.svelte
+++ b/src/routes/my-account/history/+page.svelte
@@ -1,0 +1,252 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+  const history = data.history as any[];
+
+  let search = $state('');
+  let start = $state('');
+  let end = $state('');
+  let material = $state('');
+
+  function exportCsv() {
+    const rows = history.map((entry) => ({
+      Title: entry.marcRecord?.title_statement?.a ?? 'Untitled',
+      Author: entry.marcRecord?.main_entry_personal_name?.a ?? '',
+      Action: entry.action,
+      Date: new Date(entry.action_date).toISOString(),
+      Barcode: entry.item?.barcode ?? '',
+    }));
+
+    const header = Object.keys(rows[0] ?? { Title: '', Author: '', Action: '', Date: '', Barcode: '' });
+    const csv = [header.join(','), ...rows.map((r) => header.map((h) => `"${(r as any)[h]}"`).join(','))].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'checkout-history.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">Privacy-aware</p>
+      <h1>Checkout History</h1>
+      <p class="muted">Opt-in to keep a history of items you borrow. Export or clear whenever you like.</p>
+    </div>
+    <form method="post" action="?/toggle_opt_in">
+      <button type="submit" class="btn primary">
+        {data.optedIn ? 'Disable history' : 'Enable history'}
+      </button>
+    </form>
+  </header>
+
+  {#if !data.optedIn}
+    <div class="card">
+      <p class="muted">
+        History tracking is disabled. Enable it to see past checkouts, filter by date or material,
+        and export to CSV.
+      </p>
+    </div>
+  {:else}
+    <section class="filters">
+      <label>
+        Search
+        <input type="text" bind:value={search} placeholder="Title or author" />
+      </label>
+      <label>
+        Start date
+        <input type="date" bind:value={start} />
+      </label>
+      <label>
+        End date
+        <input type="date" bind:value={end} />
+      </label>
+      <label>
+        Material
+        <select bind:value={material}>
+          <option value="">Any</option>
+          <option value="book">Book</option>
+          <option value="ebook">eBook</option>
+          <option value="audio">Audio</option>
+          <option value="video">Video</option>
+        </select>
+      </label>
+      <button
+        class="btn secondary"
+        onclick={(e) => {
+          e.preventDefault();
+          const params = new URLSearchParams();
+          if (search) params.set('search', search);
+          if (start) params.set('start', start);
+          if (end) params.set('end', end);
+          if (material) params.set('material', material);
+          window.location.search = params.toString();
+        }}
+      >
+        Apply
+      </button>
+      <button class="btn ghost" type="button" onclick={exportCsv}>Export CSV</button>
+      <form method="post" action="?/clear_history">
+        <button class="btn danger" type="submit">Clear history</button>
+      </form>
+    </section>
+
+    {#if history.length === 0}
+      <div class="card">
+        <p class="muted">No history yet.</p>
+      </div>
+    {:else}
+      <div class="history-list">
+        {#each history as entry}
+          <article class="card entry">
+            <div>
+              <p class="title">{entry.marcRecord?.title_statement?.a ?? 'Untitled'}</p>
+              <p class="muted">{entry.marcRecord?.main_entry_personal_name?.a ?? 'Unknown author'}</p>
+              <p class="muted small">Barcode: {entry.item?.barcode ?? '—'}</p>
+            </div>
+            <div class="meta">
+              <span class="pill">{entry.action}</span>
+              <p class="muted">{new Date(entry.action_date).toLocaleString()}</p>
+            </div>
+          </article>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: #e73b42;
+    margin: 0 0 0.25rem 0;
+  }
+
+  .muted {
+    color: #6b7280;
+    margin: 0.2rem 0;
+  }
+
+  .card {
+    background: #fff;
+    border: 1px solid #f0f0f0;
+    border-radius: 12px;
+    padding: 1rem;
+  }
+
+  .filters {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: 600;
+    color: #374151;
+  }
+
+  input,
+  select {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 0.6rem;
+  }
+
+  .btn {
+    border: 1px solid #e5e7eb;
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .btn.primary {
+    background: #e73b42;
+    color: #fff;
+    border-color: #e73b42;
+  }
+
+  .btn.secondary {
+    background: #fff;
+  }
+
+  .btn.ghost {
+    background: #f9fafb;
+  }
+
+  .btn.danger {
+    background: #fff5f5;
+    color: #e73b42;
+    border-color: #f4c7c7;
+  }
+
+  .history-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .entry {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .title {
+    margin: 0;
+    font-weight: 700;
+  }
+
+  .small {
+    font-size: 0.9rem;
+  }
+
+  .meta {
+    text-align: right;
+  }
+
+  .pill {
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: #3730a3;
+    font-weight: 700;
+    display: inline-block;
+    margin-bottom: 0.25rem;
+  }
+
+  @media (max-width: 768px) {
+    .entry {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .meta {
+      text-align: left;
+    }
+  }
+</style>

--- a/src/routes/my-account/holds/+page.server.ts
+++ b/src/routes/my-account/holds/+page.server.ts
@@ -1,0 +1,140 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+async function requirePatron(locals: App.Locals) {
+  const { session } = await locals.safeGetSession();
+  if (!session) throw redirect(303, '/my-account/login');
+
+  const { data: patron } = await locals.supabase
+    .from('patrons')
+    .select('*, preferences:patron_preferences(*)')
+    .eq('user_id', session.user.id)
+    .single();
+
+  if (!patron) throw redirect(303, '/my-account/login');
+  return patron;
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const patron = await requirePatron(locals);
+
+  const { data: holds } = await locals.supabase
+    .from('holds')
+    .select(
+      `
+      id,
+      status,
+      hold_date,
+      queue_position,
+      pickup_location,
+      suspended_until,
+      notification_channels,
+      marc_record:marc_records (
+        id,
+        title_statement,
+        main_entry_personal_name
+      )
+    `
+    )
+    .eq('patron_id', patron.id)
+    .in('status', ['placed', 'in_transit', 'available', 'picked_up', 'suspended'])
+    .order('hold_date', { ascending: true });
+
+  const normalized =
+    holds?.map((hold) => ({
+      ...hold,
+      marc_record: Array.isArray(hold.marc_record) ? hold.marc_record[0] : hold.marc_record,
+    })) ?? [];
+
+  return {
+    holds: normalized as any[],
+    preferences: patron.preferences,
+  };
+};
+
+export const actions: Actions = {
+  cancel: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const holdId = form.get('holdId') as string;
+
+    const { error } = await locals.supabase
+      .from('holds')
+      .update({
+        status: 'cancelled',
+        cancellation_date: new Date().toISOString(),
+      })
+      .eq('id', holdId)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to cancel hold' });
+    }
+
+    throw redirect(303, '/my-account/holds');
+  },
+  suspend: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const holdId = form.get('holdId') as string;
+    const until = form.get('until') as string;
+
+    const { error } = await locals.supabase
+      .from('holds')
+      .update({
+        status: 'suspended',
+        suspended_until: until || null,
+      })
+      .eq('id', holdId)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to suspend hold' });
+    }
+
+    throw redirect(303, '/my-account/holds');
+  },
+  resume: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const holdId = form.get('holdId') as string;
+
+    const { error } = await locals.supabase
+      .from('holds')
+      .update({
+        status: 'placed',
+        suspended_until: null,
+      })
+      .eq('id', holdId)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to resume hold' });
+    }
+
+    throw redirect(303, '/my-account/holds');
+  },
+  notifications: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const holdId = form.get('holdId') as string;
+    const email = form.get('email') === 'on';
+    const sms = form.get('sms') === 'on';
+
+    const channels = [];
+    if (email) channels.push('email');
+    if (sms) channels.push('sms');
+
+    const { error } = await locals.supabase
+      .from('holds')
+      .update({ notification_channels: channels })
+      .eq('id', holdId)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to save preferences' });
+    }
+
+    throw redirect(303, '/my-account/holds');
+  },
+};

--- a/src/routes/my-account/holds/+page.svelte
+++ b/src/routes/my-account/holds/+page.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+  const holds = data.holds as any[];
+</script>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">Queue management</p>
+      <h1>Holds</h1>
+      <p class="muted">Track your spot in line, change pickup locations, and pause during vacations.</p>
+    </div>
+    <a class="btn primary" href="/catalog/search">Place new hold</a>
+  </header>
+
+  {#if holds.length === 0}
+    <div class="card">
+      <p class="muted">No active holds.</p>
+    </div>
+  {:else}
+    <div class="holds">
+      {#each holds as hold}
+        <article class="card hold">
+          <div class="info">
+            <p class="title">{hold.marc_record?.title_statement?.a ?? 'Untitled'}</p>
+            <p class="muted">{hold.marc_record?.main_entry_personal_name?.a ?? 'Unknown author'}</p>
+            <div class="tags">
+              <span class="pill">Status: {hold.status.replace('_', ' ')}</span>
+              {#if hold.queue_position}
+                <span class="pill subtle">Queue #{hold.queue_position}</span>
+              {/if}
+              <span class="pill subtle">{hold.pickup_location ?? 'Pickup desk'}</span>
+              {#if hold.suspended_until}
+                <span class="pill warn">Suspended until {new Date(hold.suspended_until).toLocaleDateString()}</span>
+              {/if}
+            </div>
+          </div>
+          <div class="actions">
+            {#if hold.status !== 'picked_up'}
+              <form method="post" action="?/cancel">
+                <input type="hidden" name="holdId" value={hold.id} />
+                <button type="submit" class="btn ghost">Cancel</button>
+              </form>
+            {/if}
+            {#if hold.status !== 'suspended'}
+              <form method="post" action="?/suspend">
+                <input type="hidden" name="holdId" value={hold.id} />
+                <label class="muted small">
+                  Suspend until
+                  <input type="date" name="until" />
+                </label>
+                <button class="btn secondary" type="submit">Suspend</button>
+              </form>
+            {:else}
+              <form method="post" action="?/resume">
+                <input type="hidden" name="holdId" value={hold.id} />
+                <button class="btn secondary" type="submit">Resume</button>
+              </form>
+            {/if}
+
+            <form method="post" action="?/notifications" class="notification-form">
+              <input type="hidden" name="holdId" value={hold.id} />
+              <label><input type="checkbox" name="email" checked={hold.notification_channels?.includes('email')} /> Email</label>
+              <label><input type="checkbox" name="sms" checked={hold.notification_channels?.includes('sms')} /> SMS</label>
+              <button class="btn ghost" type="submit">Save alerts</button>
+            </form>
+          </div>
+        </article>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: #e73b42;
+    margin: 0 0 0.25rem 0;
+  }
+
+  .muted {
+    color: #6b7280;
+    margin: 0.25rem 0;
+  }
+
+  .btn {
+    border: 1px solid #e5e7eb;
+    padding: 0.6rem 0.9rem;
+    border-radius: 8px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  .btn.primary {
+    background: #e73b42;
+    color: #fff;
+    border-color: #e73b42;
+  }
+
+  .btn.secondary {
+    background: #fff;
+  }
+
+  .btn.ghost {
+    background: #f9fafb;
+  }
+
+  .holds {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .card {
+    background: #fff;
+    border: 1px solid #f0f0f0;
+    border-radius: 12px;
+    padding: 1rem;
+  }
+
+  .hold {
+    display: grid;
+    grid-template-columns: 1fr 260px;
+    gap: 1rem;
+  }
+
+  .title {
+    margin: 0;
+    font-weight: 700;
+    color: #1f2933;
+  }
+
+  .tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.35rem;
+  }
+
+  .pill {
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    background: #eef2ff;
+    color: #3730a3;
+    font-weight: 700;
+    font-size: 0.9rem;
+  }
+
+  .pill.subtle {
+    background: #f9fafb;
+    color: #4b5563;
+  }
+
+  .pill.warn {
+    background: #fff7ed;
+    color: #c05621;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  .notification-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .small {
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 900px) {
+    .hold {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/routes/my-account/saved-searches/+page.server.ts
+++ b/src/routes/my-account/saved-searches/+page.server.ts
@@ -1,0 +1,97 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+async function requirePatron(locals: App.Locals) {
+  const { session } = await locals.safeGetSession();
+  if (!session) throw redirect(303, '/my-account/login');
+
+  const { data: patron } = await locals.supabase.from('patrons').select('id').eq('user_id', session.user.id).single();
+  if (!patron) throw redirect(303, '/my-account/login');
+  return patron;
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const patron = await requirePatron(locals);
+
+  const { data: searches } = await locals.supabase
+    .from('saved_searches')
+    .select('*')
+    .eq('patron_id', patron.id)
+    .order('updated_at', { ascending: false });
+
+  return {
+    searches: searches ?? [],
+  };
+};
+
+export const actions: Actions = {
+  create: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const name = form.get('name') as string;
+    const query = form.get('query') as string;
+    const alert = form.get('alert') === 'on';
+    const frequency = (form.get('frequency') as string) || 'weekly';
+
+    const payload = {
+      patron_id: patron.id,
+      name,
+      query: { q: query },
+      send_email_alerts: alert,
+      alert_frequency: frequency,
+    };
+
+    const { error } = await locals.supabase.from('saved_searches').insert(payload);
+
+    if (error) {
+      return fail(500, { message: 'Unable to save search' });
+    }
+
+    throw redirect(303, '/my-account/saved-searches');
+  },
+
+  update: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const id = form.get('id') as string;
+    const name = form.get('name') as string;
+    const query = form.get('query') as string;
+    const alert = form.get('alert') === 'on';
+    const frequency = (form.get('frequency') as string) || 'weekly';
+
+    const { error } = await locals.supabase
+      .from('saved_searches')
+      .update({
+        name,
+        query: { q: query },
+        send_email_alerts: alert,
+        alert_frequency: frequency,
+      })
+      .eq('id', id)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to update search' });
+    }
+
+    throw redirect(303, '/my-account/saved-searches');
+  },
+
+  delete: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const id = form.get('id') as string;
+
+    const { error } = await locals.supabase
+      .from('saved_searches')
+      .delete()
+      .eq('id', id)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to delete search' });
+    }
+
+    throw redirect(303, '/my-account/saved-searches');
+  },
+};

--- a/src/routes/my-account/saved-searches/+page.svelte
+++ b/src/routes/my-account/saved-searches/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  let name = $state('');
+  let query = $state('');
+  let alert = $state(true);
+  let frequency = $state('weekly');
+</script>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">Keep tabs on new items</p>
+      <h1>Saved Searches</h1>
+      <p class="muted">Save frequent searches and receive alerts when new items match.</p>
+    </div>
+  </header>
+
+  <section class="card form">
+    <h2>Create search</h2>
+    <form method="post" action="?/create" class="form-grid">
+      <label>
+        Name
+        <input name="name" bind:value={name} required />
+      </label>
+      <label>
+        Query
+        <input name="query" bind:value={query} required placeholder="title: dogs AND author: carl" />
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="alert" checked={alert} />
+        Email alerts
+      </label>
+      <label>
+        Frequency
+        <select name="frequency" bind:value={frequency}>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+      </label>
+      <button class="btn primary" type="submit">Save search</button>
+    </form>
+  </section>
+
+  <section class="card">
+    <div class="section-header">
+      <h2>Saved searches</h2>
+    </div>
+    {#if data.searches.length === 0}
+      <p class="muted">No saved searches yet.</p>
+    {:else}
+      <ul class="list">
+        {#each data.searches as search}
+          <li class="item">
+            <div>
+              <p class="title">{search.name}</p>
+              <p class="muted">
+                Last run: {search.last_run_at ? new Date(search.last_run_at).toLocaleString() : 'Never'}
+                · Alerts: {search.send_email_alerts ? search.alert_frequency : 'Off'}
+              </p>
+              <a class="text-link" href={`/catalog/search?q=${encodeURIComponent(search.query?.q ?? '')}`}>
+                Run search
+              </a>
+            </div>
+            <div class="controls">
+              <form method="post" action="?/update" class="inline-form">
+                <input type="hidden" name="id" value={search.id} />
+                <input type="hidden" name="name" value={search.name} />
+                <input type="hidden" name="query" value={search.query?.q ?? ''} />
+                <label class="checkbox">
+                  <input type="checkbox" name="alert" checked={search.send_email_alerts} />
+                  Email
+                </label>
+                <select name="frequency" value={search.alert_frequency}>
+                  <option value="daily">Daily</option>
+                  <option value="weekly">Weekly</option>
+                  <option value="monthly">Monthly</option>
+                </select>
+                <button class="btn secondary" type="submit">Update</button>
+              </form>
+              <form method="post" action="?/delete">
+                <input type="hidden" name="id" value={search.id} />
+                <button class="btn ghost" type="submit">Delete</button>
+              </form>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: #e73b42;
+    margin: 0 0 0.25rem 0;
+  }
+
+  .muted {
+    color: #6b7280;
+    margin: 0.25rem 0;
+  }
+
+  .card {
+    background: #fff;
+    border: 1px solid #f0f0f0;
+    border-radius: 12px;
+    padding: 1rem;
+  }
+
+  .form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 0.75rem;
+    align-items: end;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: 600;
+  }
+
+  input,
+  select {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 0.6rem;
+  }
+
+  .checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .btn {
+    border: 1px solid #e5e7eb;
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: 700;
+  }
+
+  .btn.primary {
+    background: #e73b42;
+    color: #fff;
+    border-color: #e73b42;
+  }
+
+  .btn.secondary {
+    background: #f9fafb;
+  }
+
+  .btn.ghost {
+    background: #fff;
+  }
+
+  .list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .item {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border: 1px solid #f4f4f5;
+    border-radius: 10px;
+    align-items: center;
+  }
+
+  .title {
+    margin: 0;
+    font-weight: 700;
+    color: #1f2933;
+  }
+
+  .controls {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .inline-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .text-link {
+    color: #e73b42;
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  @media (max-width: 900px) {
+    .item {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .controls {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+</style>

--- a/src/routes/my-account/settings/+page.server.ts
+++ b/src/routes/my-account/settings/+page.server.ts
@@ -1,0 +1,113 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+
+async function requirePatron(locals: App.Locals) {
+  const { session } = await locals.safeGetSession();
+  if (!session) throw redirect(303, '/my-account/login');
+
+  const { data: patron } = await locals.supabase
+    .from('patrons')
+    .select('*, preferences:patron_preferences(*)')
+    .eq('user_id', session.user.id)
+    .single();
+
+  if (!patron) throw redirect(303, '/my-account/login');
+  return patron;
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+  const patron = await requirePatron(locals);
+  return { patron };
+};
+
+export const actions: Actions = {
+  contact: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+
+    const updates = {
+      email: form.get('email') as string | null,
+      phone: form.get('phone') as string | null,
+      address_line1: form.get('address1') as string | null,
+      address_line2: form.get('address2') as string | null,
+      city: form.get('city') as string | null,
+      state_province: form.get('state') as string | null,
+      postal_code: form.get('postal') as string | null,
+    };
+
+    const { error } = await locals.supabase.from('patrons').update(updates).eq('id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to update contact info' });
+    }
+
+    throw redirect(303, '/my-account/settings');
+  },
+
+  preferences: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+
+    const prefs = {
+      email_opt_in: form.get('email_opt_in') === 'on',
+      sms_opt_in: form.get('sms_opt_in') === 'on',
+      sms_number: (form.get('sms_number') as string) || null,
+      default_pickup_location: (form.get('pickup') as string) || null,
+      digital_receipts: form.get('digital_receipts') === 'on',
+      marketing_opt_out: form.get('marketing_opt_out') === 'on',
+      notice_lead_time_days: Number(form.get('notice_lead_time_days') ?? 3),
+      checkout_history_opt_in: form.get('checkout_history_opt_in') === 'on',
+    };
+
+    const { error } = await locals.supabase
+      .from('patron_preferences')
+      .update(prefs)
+      .eq('patron_id', patron.id);
+
+    if (error) {
+      return fail(500, { message: 'Unable to save preferences' });
+    }
+
+    throw redirect(303, '/my-account/settings');
+  },
+
+  pin: async ({ request, locals }) => {
+    const patron = await requirePatron(locals);
+    const form = await request.formData();
+    const pin = form.get('pin') as string;
+    const confirm = form.get('confirm') as string;
+
+    if (!pin || pin !== confirm) {
+      return fail(400, { message: 'PINs do not match' });
+    }
+
+    const { error } = await locals.supabase.rpc('set_patron_pin', {
+      target_patron: patron.id,
+      new_pin: pin,
+    });
+
+    if (error) {
+      return fail(500, { message: 'Unable to update PIN' });
+    }
+
+    throw redirect(303, '/my-account/settings?pin=1');
+  },
+
+  password: async ({ request, locals }) => {
+    const form = await request.formData();
+    const newPassword = form.get('password') as string;
+    const confirm = form.get('confirm') as string;
+
+    if (!newPassword || newPassword !== confirm) {
+      return fail(400, { message: 'Passwords do not match' });
+    }
+
+    const { error } = await locals.supabase.auth.updateUser({ password: newPassword });
+
+    if (error) {
+      return fail(500, { message: 'Unable to update password' });
+    }
+
+    throw redirect(303, '/my-account/settings?password=1');
+  },
+};

--- a/src/routes/my-account/settings/+page.svelte
+++ b/src/routes/my-account/settings/+page.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  let contact = $state({
+    email: data.patron.email ?? '',
+    phone: data.patron.phone ?? '',
+    address1: data.patron.address_line1 ?? '',
+    address2: data.patron.address_line2 ?? '',
+    city: data.patron.city ?? '',
+    state: data.patron.state_province ?? '',
+    postal: data.patron.postal_code ?? '',
+  });
+
+  let prefs = $state({
+    email_opt_in: data.patron.preferences?.email_opt_in ?? true,
+    sms_opt_in: data.patron.preferences?.sms_opt_in ?? false,
+    sms_number: data.patron.preferences?.sms_number ?? '',
+    default_pickup_location: data.patron.preferences?.default_pickup_location ?? '',
+    digital_receipts: data.patron.preferences?.digital_receipts ?? true,
+    marketing_opt_out: data.patron.preferences?.marketing_opt_out ?? true,
+    notice_lead_time_days: data.patron.preferences?.notice_lead_time_days ?? 3,
+    checkout_history_opt_in: data.patron.preferences?.checkout_history_opt_in ?? false,
+  });
+
+  let pin = $state('');
+  let pinConfirm = $state('');
+  let password = $state('');
+  let passwordConfirm = $state('');
+</script>
+
+<div class="page">
+  <header class="header">
+    <div>
+      <p class="eyebrow">Account settings</p>
+      <h1>Profile & Preferences</h1>
+      <p class="muted">Update contact information, communication choices, and credentials.</p>
+    </div>
+  </header>
+
+  <section class="grid two-col">
+    <form method="post" action="?/contact" class="card form">
+      <h2>Contact information</h2>
+      <label>
+        Email
+        <input name="email" type="email" bind:value={contact.email} />
+      </label>
+      <label>
+        Phone
+        <input name="phone" type="tel" bind:value={contact.phone} />
+      </label>
+      <label>
+        Address line 1
+        <input name="address1" bind:value={contact.address1} />
+      </label>
+      <label>
+        Address line 2
+        <input name="address2" bind:value={contact.address2} />
+      </label>
+      <div class="grid two-col">
+        <label>
+          City
+          <input name="city" bind:value={contact.city} />
+        </label>
+        <label>
+          State/Province
+          <input name="state" bind:value={contact.state} />
+        </label>
+      </div>
+      <label>
+        Postal code
+        <input name="postal" bind:value={contact.postal} />
+      </label>
+      <button class="btn primary" type="submit">Save contact info</button>
+    </form>
+
+    <form method="post" action="?/preferences" class="card form">
+      <h2>Communication & privacy</h2>
+      <label class="checkbox">
+        <input type="checkbox" name="email_opt_in" checked={prefs.email_opt_in} />
+        Email notices
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="sms_opt_in" checked={prefs.sms_opt_in} />
+        SMS notices
+      </label>
+      <label>
+        SMS number
+        <input name="sms_number" bind:value={prefs.sms_number} />
+      </label>
+      <label>
+        Default pickup location
+        <input name="pickup" bind:value={prefs.default_pickup_location} />
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="digital_receipts" checked={prefs.digital_receipts} />
+        Digital receipts
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="marketing_opt_out" checked={prefs.marketing_opt_out} />
+        Opt out of marketing
+      </label>
+      <label>
+        Notice lead time (days)
+        <input name="notice_lead_time_days" type="number" min="0" bind:value={prefs.notice_lead_time_days} />
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="checkout_history_opt_in" checked={prefs.checkout_history_opt_in} />
+        Store checkout history
+      </label>
+      <button class="btn primary" type="submit">Save preferences</button>
+    </form>
+  </section>
+
+  <section class="grid two-col">
+    <form method="post" action="?/pin" class="card form">
+      <h2>Change PIN (card login)</h2>
+      <label>
+        New PIN
+        <input name="pin" type="password" bind:value={pin} required />
+      </label>
+      <label>
+        Confirm PIN
+        <input name="confirm" type="password" bind:value={pinConfirm} required />
+      </label>
+      <button class="btn secondary" type="submit">Update PIN</button>
+    </form>
+
+    <form method="post" action="?/password" class="card form">
+      <h2>Change password</h2>
+      <label>
+        New password
+        <input name="password" type="password" bind:value={password} required />
+      </label>
+      <label>
+        Confirm password
+        <input name="confirm" type="password" bind:value={passwordConfirm} required />
+      </label>
+      <button class="btn secondary" type="submit">Update password</button>
+    </form>
+  </section>
+</div>
+
+<style>
+  .page {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    color: #e73b42;
+    margin: 0 0 0.25rem 0;
+  }
+
+  .muted {
+    color: #6b7280;
+    margin: 0.25rem 0;
+  }
+
+  .grid {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .two-col {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+
+  .card {
+    background: #fff;
+    border: 1px solid #f0f0f0;
+    border-radius: 12px;
+    padding: 1rem;
+  }
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-weight: 600;
+  }
+
+  .checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  input {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 0.65rem;
+  }
+
+  .btn {
+    border: 1px solid #e5e7eb;
+    padding: 0.65rem 0.9rem;
+    border-radius: 8px;
+    background: #fff;
+    cursor: pointer;
+    font-weight: 700;
+  }
+
+  .btn.primary {
+    background: #e73b42;
+    color: #fff;
+    border-color: #e73b42;
+  }
+
+  .btn.secondary {
+    background: #f9fafb;
+  }
+</style>


### PR DESCRIPTION
## Summary
- add patron self-service portal routes with dashboard, checkouts, holds, fines, history, settings, and saved searches
- implement Supabase-backed actions for renewals, holds management, preferences, and payments, plus card/PIN-aware login
- extend schema with PIN hashing, preferences, notifications, fines/payments, and saved search tables, updating documentation

## Testing
- npm run check *(fails: existing type/a11y issues in admin acquisitions/receiving page)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69553741e4108330a29ba468ec2d7134)