### PR TITLE
Implement authority control updates

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -262,6 +262,35 @@ CREATE POLICY "Authenticated users can manage serial_issues"
   USING (true);
 ```
 
+## Authority Control
+
+Authority control tables track authorized headings, cross-references, and links to MARC bibliographic records.
+
+### `authorities`
+- `id` UUID primary key with timestamps
+- `heading` authorized form of the name/subject
+- `type` ENUM-like string: `personal_name`, `corporate_name`, `geographic_name`, `topical_subject`
+- `source` (`lcnaf`, `lcsh`, `local`) plus identifiers `lccn`, `viaf_id`, `fast_id`
+- `variant_forms` TEXT[] for non-authorized headings
+- `marc_authority` JSONB for the raw LC record
+- `usage_count` cached count of linked bibliographic records
+- `search_vector` TSVECTOR for full-text/fuzzy matching
+
+### `authority_cross_refs`
+- Cross-reference rows tied to an `authority_id`
+- `ref_type`: `see`, `see_also`, `see_from`
+- `reference_text` free-text heading, optional `related_authority_id`, `note`
+
+### `marc_authority_links`
+- Joins MARC bib records to authorities
+- `marc_record_id`, `authority_id`, `marc_field` (`100`, `650`, etc.), and `field_index` for repeatable fields
+- `confidence` (0–1) and `is_automatic` to track automated matches
+- Unique constraint on `marc_record_id`, `marc_field`, `field_index` prevents duplicate links
+
+### `authority_update_log`
+- Audit table capturing `action` (`created`, `updated`, `merged`, `deleted`, `synced_from_loc`, `heading_corrected`)
+- Stores `old_value`, `new_value`, `records_affected`, `performed_by`, and notes for traceability
+
 ## Setup Instructions
 
 1. Go to your Supabase project dashboard

--- a/migrations/018_authority_control.sql
+++ b/migrations/018_authority_control.sql
@@ -399,12 +399,15 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Function to find unauthorized headings in MARC records
+DROP FUNCTION IF EXISTS find_unauthorized_headings(VARCHAR);
+
 CREATE OR REPLACE FUNCTION find_unauthorized_headings(
   field_type VARCHAR(10) DEFAULT NULL
 )
 RETURNS TABLE (
   marc_record_id UUID,
   field VARCHAR(10),
+  field_index INTEGER,
   heading TEXT,
   suggested_authority_id UUID,
   suggested_heading TEXT,
@@ -416,6 +419,7 @@ BEGIN
   SELECT
     m.id as marc_record_id,
     '100' as field,
+    0 as field_index,
     m.main_entry_personal_name->>'a' as heading,
     a.id as suggested_authority_id,
     a.heading as suggested_heading,
@@ -441,6 +445,7 @@ BEGIN
   SELECT
     m.id as marc_record_id,
     '650' as field,
+    (t.idx - 1) as field_index,
     subj->>'a' as heading,
     a.id as suggested_authority_id,
     a.heading as suggested_heading,

--- a/src/routes/admin/cataloging/authorities/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/+page.svelte
@@ -15,10 +15,8 @@
 		{ value: '', label: 'All Types' },
 		{ value: 'personal_name', label: 'Personal Names' },
 		{ value: 'corporate_name', label: 'Corporate Names' },
-		{ value: 'meeting_name', label: 'Meeting Names' },
 		{ value: 'geographic_name', label: 'Geographic Names' },
-		{ value: 'topical_subject', label: 'Topical Subjects' },
-		{ value: 'genre_form', label: 'Genre/Form' }
+		{ value: 'topical_subject', label: 'Topical Subjects' }
 	];
 
 	const sources = [
@@ -36,8 +34,7 @@
 			corporate_name: 'Corporate Name',
 			meeting_name: 'Meeting Name',
 			geographic_name: 'Geographic Name',
-			topical_subject: 'Topical Subject',
-			genre_form: 'Genre/Form'
+			topical_subject: 'Topical Subject'
 		};
 		return typeMap[type] || type;
 	}

--- a/src/routes/admin/cataloging/authorities/[id]/+page.server.ts
+++ b/src/routes/admin/cataloging/authorities/[id]/+page.server.ts
@@ -1,0 +1,46 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ params, locals: { supabase } }) => {
+	const authorityId = params.id;
+
+	const { data: authority, error: fetchError } = await supabase
+		.from('authorities')
+		.select(
+			`
+			*,
+			authority_cross_refs (*),
+			marc_authority_links (
+				marc_field,
+				field_index,
+				confidence,
+				is_automatic,
+				marc_records:marc_record_id (
+					id,
+					title_statement,
+					material_type
+				)
+			)
+		`
+		)
+		.eq('id', authorityId)
+		.single();
+
+	if (fetchError || !authority) {
+		throw error(404, 'Authority not found');
+	}
+
+	const { data: candidates } = await supabase.rpc('search_authorities', {
+		search_term: authority.heading,
+		authority_type: authority.type,
+		limit_count: 6
+	});
+
+	const mergeCandidates = (candidates || []).filter((candidate: any) => candidate.id !== authorityId);
+
+	return {
+		authority,
+		authorityId,
+		mergeCandidates
+	};
+};

--- a/src/routes/admin/cataloging/authorities/[id]/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/[id]/+page.svelte
@@ -1,0 +1,572 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	let authority = $state<any>(data.authority);
+	let heading = $state(authority.heading || '');
+	let type = $state(authority.type || 'personal_name');
+	let source = $state(authority.source || 'local');
+	let lccn = $state(authority.lccn || '');
+	let note = $state(authority.note || '');
+	let variantForms = $state<string[]>(authority.variant_forms || []);
+	let crossReferences = $state<any[]>(authority.authority_cross_refs || []);
+	let mergeTarget = $state<string>(data.mergeCandidates?.[0]?.id || '');
+	let message = $state('');
+	let messageType = $state<'success' | 'error' | 'info'>('info');
+	let saving = $state(false);
+
+	const authorityTypes = [
+		{ value: 'personal_name', label: 'Personal Name' },
+		{ value: 'corporate_name', label: 'Corporate Name' },
+		{ value: 'geographic_name', label: 'Geographic Name' },
+		{ value: 'topical_subject', label: 'Topical Subject' }
+	];
+
+	const sources = [
+		{ value: 'lcnaf', label: 'LC Names (LCNAF)' },
+		{ value: 'lcsh', label: 'LC Subjects (LCSH)' },
+		{ value: 'local', label: 'Local' }
+	];
+
+	function addVariant() {
+		variantForms = [...variantForms, ''];
+	}
+
+	function removeVariant(index: number) {
+		variantForms = variantForms.filter((_, i) => i !== index);
+	}
+
+	function addCrossRef() {
+		crossReferences = [
+			...crossReferences,
+			{ ref_type: 'see', reference_text: '', note: '' }
+		];
+	}
+
+	function removeCrossRef(index: number) {
+		crossReferences = crossReferences.filter((_, i) => i !== index);
+	}
+
+	async function saveAuthority() {
+		saving = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/authorities', {
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					id: data.authorityId,
+					heading,
+					type,
+					source,
+					lccn: lccn || null,
+					note,
+					variant_forms: variantForms.filter((v) => v.trim()),
+					cross_references: crossReferences
+				})
+			});
+
+			if (!response.ok) {
+				const error = await response.json();
+				throw new Error(error.message || 'Failed to save authority');
+			}
+
+			const result = await response.json();
+			authority = result.authority;
+			message = 'Authority updated successfully';
+			messageType = 'success';
+		} catch (err: any) {
+			message = err.message || 'Failed to save authority';
+			messageType = 'error';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function mergeAuthority() {
+		if (!mergeTarget) {
+			message = 'Select a target authority to merge into';
+			messageType = 'error';
+			return;
+		}
+
+		if (
+			!confirm(
+				'Merge this authority into the selected one? Links and cross-references will be moved.'
+			)
+		) {
+			return;
+		}
+
+		saving = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/authorities/merge', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					source_id: data.authorityId,
+					target_id: mergeTarget
+				})
+			});
+
+			if (!response.ok) {
+				const error = await response.json();
+				throw new Error(error.message || 'Failed to merge authorities');
+			}
+
+			const result = await response.json();
+			message = 'Merged successfully. Redirecting to target authority...';
+			messageType = 'success';
+
+			setTimeout(() => goto(`/admin/cataloging/authorities/${result.target.id}`), 1200);
+		} catch (err: any) {
+			message = err.message || 'Failed to merge authorities';
+			messageType = 'error';
+		} finally {
+			saving = false;
+		}
+	}
+
+	function formatUsageLabel(link: any) {
+		const fieldLabel = link.marc_field === '100' ? 'Personal name' : 'Subject';
+		return `${fieldLabel} • Field ${link.marc_field}${link.field_index ? ` [${link.field_index + 1}]` : ''}`;
+	}
+</script>
+
+<svelte:head>
+	<title>{heading} - Authority</title>
+</svelte:head>
+
+<div class="container">
+	<header class="page-header">
+		<h1>{heading}</h1>
+		<p>Edit authority record, variants, cross-references, and usage.</p>
+	</header>
+
+	{#if message}
+		<div class="message {messageType}">
+			{message}
+		</div>
+	{/if}
+
+	<div class="layout">
+		<section class="card">
+			<h2>Authorized Heading</h2>
+			<div class="form-grid">
+				<label>
+					<span>Heading</span>
+					<input type="text" bind:value={heading} />
+				</label>
+
+				<label>
+					<span>Type</span>
+					<select bind:value={type}>
+						{#each authorityTypes as option}
+							<option value={option.value}>{option.label}</option>
+						{/each}
+					</select>
+				</label>
+
+				<label>
+					<span>Source</span>
+					<select bind:value={source}>
+						{#each sources as option}
+							<option value={option.value}>{option.label}</option>
+						{/each}
+					</select>
+				</label>
+
+				<label>
+					<span>LCCN (optional)</span>
+					<input type="text" bind:value={lccn} placeholder="n#######" />
+				</label>
+			</div>
+
+			<label>
+				<span>Note</span>
+				<textarea rows="3" bind:value={note} placeholder="Scope note or biographical note"></textarea>
+			</label>
+
+			<div class="variant-section">
+				<div class="section-header">
+					<h3>Variant Forms</h3>
+					<button class="btn-secondary" type="button" onclick={addVariant}>Add Variant</button>
+				</div>
+
+				{#if variantForms.length === 0}
+					<p class="muted">No variant forms recorded.</p>
+				{:else}
+					<div class="variant-list">
+						{#each variantForms as variant, i}
+							<div class="variant-row">
+								<input type="text" bind:value={variantForms[i]} placeholder="Variant heading" />
+								<button class="btn-small" type="button" onclick={() => removeVariant(i)}>
+									Remove
+								</button>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<div class="crossref-section">
+				<div class="section-header">
+					<h3>Cross References</h3>
+					<button class="btn-secondary" type="button" onclick={addCrossRef}>Add Reference</button>
+				</div>
+
+				{#if crossReferences.length === 0}
+					<p class="muted">No cross-references configured.</p>
+				{:else}
+					<div class="crossref-list">
+						{#each crossReferences as ref, i}
+							<div class="crossref-row">
+								<select bind:value={crossReferences[i].ref_type}>
+									<option value="see">See (Use)</option>
+									<option value="see_also">See also</option>
+									<option value="see_from">See from</option>
+								</select>
+								<input
+									type="text"
+									bind:value={crossReferences[i].reference_text}
+									placeholder="Reference heading"
+								/>
+								<input
+									type="text"
+									bind:value={crossReferences[i].note}
+									placeholder="Note (optional)"
+								/>
+								<button class="btn-small" type="button" onclick={() => removeCrossRef(i)}>
+									Remove
+								</button>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<div class="actions">
+				<button class="btn-primary" type="button" onclick={saveAuthority} disabled={saving}>
+					{saving ? 'Saving…' : 'Save Changes'}
+				</button>
+				{#if lccn}
+					<a
+						class="btn-secondary"
+						href={`https://id.loc.gov/authorities/${type.includes('subject') ? 'subjects' : 'names'}/${lccn}`}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						View in LoC
+					</a>
+				{/if}
+			</div>
+		</section>
+
+		<section class="card">
+			<h2>Usage ({authority.usage_count || 0})</h2>
+			{#if authority.marc_authority_links?.length}
+				<ul class="usage-list">
+					{#each authority.marc_authority_links as link}
+						<li>
+							<div>
+								<div class="usage-heading">
+									{link.marc_records?.title_statement?.a || 'Untitled record'}
+								</div>
+								<div class="usage-meta">
+									<span class="badge">{formatUsageLabel(link)}</span>
+									{#if link.marc_records?.material_type}
+										<span class="badge badge-muted">{link.marc_records.material_type}</span>
+									{/if}
+									<span class="badge badge-muted">
+										{Math.round((link.confidence || 1) * 100)}% match
+									</span>
+									{#if link.is_automatic}
+										<span class="badge badge-warn">Automatic</span>
+									{/if}
+								</div>
+							</div>
+							<a
+								class="record-link"
+								href={`/admin/cataloging/edit/${link.marc_records?.id || link.marc_record_id}`}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								View record
+							</a>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="muted">No bibliographic records are currently linked to this authority.</p>
+			{/if}
+		</section>
+
+		<section class="card">
+			<h2>Merge Duplicates</h2>
+			<p class="muted">Merge this authority into another to clean up duplicates.</p>
+			<div class="merge-grid">
+				<label>
+					<span>Target authority</span>
+					<select bind:value={mergeTarget}>
+						<option value="">Select...</option>
+						{#each data.mergeCandidates as candidate}
+							<option value={candidate.id}>
+								{candidate.heading} ({Math.round((candidate.similarity_score || 0) * 100)}%)
+							</option>
+						{/each}
+					</select>
+				</label>
+				<button class="btn-primary" type="button" onclick={mergeAuthority} disabled={saving}>
+					Merge into selected
+				</button>
+			</div>
+		</section>
+	</div>
+</div>
+
+<style>
+	.container {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.page-header {
+		margin-bottom: 20px;
+	}
+
+	.page-header h1 {
+		margin: 0 0 6px 0;
+	}
+
+	.page-header p {
+		margin: 0;
+		color: #555;
+	}
+
+	.layout {
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+	}
+
+	.card {
+		background: #fff;
+		border-radius: 8px;
+		padding: 20px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+	}
+
+	.card h2 {
+		margin: 0 0 12px 0;
+	}
+
+	.form-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 12px;
+		margin-bottom: 12px;
+	}
+
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		font-weight: 600;
+		color: #333;
+		font-size: 14px;
+	}
+
+	input,
+	select,
+	textarea {
+		padding: 10px;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+		font-size: 14px;
+	}
+
+	textarea {
+		width: 100%;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin: 16px 0 8px 0;
+	}
+
+	.variant-list,
+	.crossref-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.variant-row,
+	.crossref-row {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) auto;
+		gap: 8px;
+		align-items: center;
+	}
+
+	.actions {
+		display: flex;
+		gap: 10px;
+		margin-top: 16px;
+	}
+
+	.btn-primary,
+	.btn-secondary,
+	.btn-small {
+		padding: 10px 16px;
+		border: none;
+		border-radius: 6px;
+		font-weight: 600;
+		cursor: pointer;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+	}
+
+	.btn-primary {
+		background: #e73b42;
+		color: white;
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: white;
+		color: #333;
+		border: 1px solid #ddd;
+	}
+
+	.btn-small {
+		background: #f5f5f5;
+		color: #333;
+		border: 1px solid #ddd;
+		font-size: 13px;
+	}
+
+	.message {
+		padding: 12px 16px;
+		border-radius: 6px;
+		margin-bottom: 16px;
+		border: 1px solid transparent;
+	}
+
+	.message.success {
+		background: #d4edda;
+		border-color: #c3e6cb;
+		color: #155724;
+	}
+
+	.message.error {
+		background: #f8d7da;
+		border-color: #f5c6cb;
+		color: #721c24;
+	}
+
+	.message.info {
+		background: #e7f1ff;
+		border-color: #d0e2ff;
+		color: #0b4f9c;
+	}
+
+	.muted {
+		color: #666;
+		font-size: 14px;
+	}
+
+	.usage-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.usage-list li {
+		border: 1px solid #eee;
+		border-radius: 6px;
+		padding: 12px;
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 12px;
+	}
+
+	.usage-heading {
+		font-weight: 600;
+		color: #333;
+	}
+
+	.usage-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin-top: 6px;
+	}
+
+	.badge {
+		display: inline-block;
+		padding: 4px 8px;
+		border-radius: 12px;
+		background: #e3f2fd;
+		color: #1976d2;
+		font-size: 12px;
+	}
+
+	.badge-muted {
+		background: #f1f1f1;
+		color: #444;
+	}
+
+	.badge-warn {
+		background: #fff3cd;
+		color: #856404;
+	}
+
+	.record-link {
+		font-size: 13px;
+		color: #667eea;
+		text-decoration: none;
+		font-weight: 600;
+	}
+
+	.merge-grid {
+		display: grid;
+		grid-template-columns: 2fr 1fr;
+		gap: 12px;
+		align-items: end;
+	}
+
+	@media (max-width: 768px) {
+		.variant-row,
+		.crossref-row {
+			grid-template-columns: 1fr;
+		}
+
+		.merge-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.actions {
+			flex-direction: column;
+		}
+	}
+</style>

--- a/src/routes/admin/cataloging/authorities/browse/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/browse/+page.svelte
@@ -17,24 +17,22 @@
 	];
 
 	$effect(() => {
-		loadAuthorities();
+		loadAuthorities(letter, type);
 	});
 
-	async function loadAuthorities() {
+	async function loadAuthorities(currentLetter: string, currentType: string) {
 		loading = true;
 
 		try {
 			const params = new URLSearchParams();
-			if (type) params.set('type', type);
-			params.set('limit', '100');
+			if (currentType) params.set('type', currentType);
+			params.set('limit', '200');
+			params.set('starts_with', currentLetter);
 
 			const response = await fetch(`/api/authorities?${params.toString()}`);
 			const data = await response.json();
 
-			// Filter by starting letter
-			authorities = (data.authorities || []).filter((auth: any) =>
-				auth.heading.toUpperCase().startsWith(letter)
-			);
+			authorities = data.authorities || [];
 		} catch (error) {
 			console.error('Error loading authorities:', error);
 		} finally {

--- a/src/routes/admin/cataloging/authorities/corrections/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/corrections/+page.svelte
@@ -48,17 +48,18 @@
 	}
 
 	function toggleCorrection(item: any, apply: boolean) {
+		const key = item.marc_record_id + item.field + (item.field_index ?? 0);
 		if (apply) {
-			corrections.set(item.marc_record_id + item.field, {
+			corrections.set(key, {
 				marc_record_id: item.marc_record_id,
 				field: item.field,
-				field_index: 0,
+				field_index: item.field_index ?? 0,
 				authority_id: item.suggested_authority_id,
 				old_heading: item.heading,
 				new_heading: item.suggested_heading
 			});
 		} else {
-			corrections.delete(item.marc_record_id + item.field);
+			corrections.delete(key);
 		}
 		corrections = corrections; // Trigger reactivity
 	}
@@ -205,7 +206,7 @@
 				</thead>
 				<tbody>
 					{#each unauthorized as item}
-						{@const key = item.marc_record_id + item.field}
+						{@const key = item.marc_record_id + item.field + (item.field_index ?? 0)}
 						{@const isSelected = corrections.has(key)}
 						{@const confidence = Math.round(item.confidence * 100)}
 						<tr class:selected={isSelected} class:high-confidence={confidence >= 80}>

--- a/src/routes/admin/cataloging/authorities/import/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/import/+page.svelte
@@ -1,0 +1,491 @@
+<script lang="ts">
+	let query = $state('');
+	let type = $state<'names' | 'subjects'>('names');
+	let results = $state<any[]>([]);
+	let bulkDownloads = $state<{ names: string; subjects: string } | null>(null);
+	let unauthorizedSummary = $state<any>(null);
+	let message = $state('');
+	let messageType = $state<'success' | 'error' | 'info'>('info');
+	let loading = $state(false);
+	let scheduling = $state(false);
+	let frequency = $state<'weekly' | 'monthly'>('weekly');
+	let scope = $state<'names' | 'subjects' | 'both'>('both');
+	let runNow = $state(false);
+
+	async function searchLoc() {
+		if (!query) return;
+		loading = true;
+		message = '';
+
+		try {
+			const response = await fetch(
+				`/api/authorities/loc?q=${encodeURIComponent(query)}&type=${type}`
+			);
+			if (!response.ok) {
+				throw new Error('Search failed');
+			}
+
+			const data = await response.json();
+			results = data.authorities || [];
+			bulkDownloads = data.bulkDownloads;
+		} catch (err: any) {
+			message = err.message || 'Failed to search Library of Congress';
+			messageType = 'error';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function importAuthority(authority: any) {
+		message = '';
+		messageType = 'info';
+		loading = true;
+
+		try {
+			const response = await fetch('/api/authorities/loc', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					uri: authority.uri,
+					lccn: authority.lccn
+				})
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				throw new Error(data.message || 'Import failed');
+			}
+
+			message = data.imported ? 'Authority imported' : data.message;
+			messageType = 'success';
+		} catch (err: any) {
+			message = err.message || 'Failed to import authority';
+			messageType = 'error';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadUnauthorizedSummary() {
+		const response = await fetch('/api/authorities/unauthorized?limit=10');
+		if (response.ok) {
+			const data = await response.json();
+			unauthorizedSummary = data.summary;
+		}
+	}
+
+	async function scheduleSync() {
+		scheduling = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/authorities/loc/sync', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ frequency, scope, run_now: runNow })
+			});
+
+			const data = await response.json();
+			if (!response.ok) {
+				throw new Error(data.message || 'Failed to schedule sync');
+			}
+
+			message = data.message;
+			messageType = 'success';
+		} catch (err: any) {
+			message = err.message || 'Failed to schedule sync';
+			messageType = 'error';
+		} finally {
+			scheduling = false;
+		}
+	}
+
+	loadUnauthorizedSummary();
+</script>
+
+<svelte:head>
+	<title>Import Authorities - Library of Congress</title>
+</svelte:head>
+
+<div class="container">
+	<header class="page-header">
+		<h1>Library of Congress Authorities</h1>
+		<p>Search LCNAF/LCSH, import records, and schedule regular updates.</p>
+	</header>
+
+	{#if message}
+		<div class="message {messageType}">{message}</div>
+	{/if}
+
+	<section class="card">
+		<div class="search-grid">
+			<input
+				type="text"
+				placeholder="Search LCNAF/LCSH (e.g., Twain, Mark)"
+				bind:value={query}
+				onkeydown={(e) => e.key === 'Enter' && searchLoc()}
+			/>
+			<select bind:value={type}>
+				<option value="names">Names (LCNAF)</option>
+				<option value="subjects">Subjects (LCSH)</option>
+			</select>
+			<button class="btn-primary" onclick={searchLoc} disabled={loading}>
+				{loading ? 'Searching…' : 'Search LoC'}
+			</button>
+		</div>
+
+		{#if bulkDownloads}
+			<div class="bulk-downloads">
+				<h3>Bulk files</h3>
+				<p>Use bulk RDF dumps for offline synchronization.</p>
+				<ul>
+					<li>
+						<a href={bulkDownloads.names} target="_blank" rel="noopener noreferrer">LCNAF (Names)</a>
+					</li>
+					<li>
+						<a href={bulkDownloads.subjects} target="_blank" rel="noopener noreferrer">LCSH (Subjects)</a>
+					</li>
+				</ul>
+			</div>
+		{/if}
+
+		{#if results.length > 0}
+			<div class="results">
+				<h3>{results.length} results</h3>
+				<ul>
+					{#each results as authority}
+						<li>
+							<div class="heading-row">
+								<div>
+									<div class="heading">{authority.label || authority.heading}</div>
+									<div class="meta">
+										{#if authority.lccn}<span class="badge">LCCN {authority.lccn}</span>{/if}
+										<span class="badge">{type === 'subjects' ? 'LCSH' : 'LCNAF'}</span>
+									</div>
+								</div>
+								<button class="btn-primary" onclick={() => importAuthority(authority)} disabled={loading}>
+									Import
+								</button>
+							</div>
+
+							{#if authority.variants?.length}
+								<div class="variants">
+									<strong>Variants:</strong> {authority.variants.slice(0, 4).join(', ')}
+								</div>
+							{/if}
+
+							{#if authority.related?.length}
+								<div class="variants">
+									<strong>See also:</strong> {authority.related.slice(0, 4).join(', ')}
+								</div>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{:else if !loading}
+			<p class="muted">Search above to retrieve authority records.</p>
+		{/if}
+	</section>
+
+	<section class="card">
+		<div class="section-header">
+			<h2>Scheduled Updates</h2>
+			<button class="btn-primary" onclick={scheduleSync} disabled={scheduling}>
+				{scheduling ? 'Scheduling…' : 'Save Schedule'}
+			</button>
+		</div>
+		<div class="schedule-grid">
+			<label>
+				<span>Frequency</span>
+				<select bind:value={frequency}>
+					<option value="weekly">Weekly</option>
+					<option value="monthly">Monthly</option>
+				</select>
+			</label>
+			<label>
+				<span>Scope</span>
+				<select bind:value={scope}>
+					<option value="names">Names</option>
+					<option value="subjects">Subjects</option>
+					<option value="both">Both</option>
+				</select>
+			</label>
+			<label class="checkbox">
+				<input type="checkbox" bind:checked={runNow} />
+				Run immediately
+			</label>
+		</div>
+	</section>
+
+	<section class="card">
+		<h2>Unauthorized Headings</h2>
+		{#if unauthorizedSummary}
+			<div class="coverage">
+				<div class="stat">
+					<div class="stat-value">{unauthorizedSummary.coverage || 0}%</div>
+					<div class="stat-label">Authority coverage</div>
+				</div>
+				<div class="stat">
+					<div class="stat-value">{unauthorizedSummary.total_unauthorized}</div>
+					<div class="stat-label">Unauthorized headings</div>
+				</div>
+				<div class="stat">
+					<div class="stat-value">{unauthorizedSummary.unique_headings}</div>
+					<div class="stat-label">Unique forms</div>
+				</div>
+			</div>
+			{#if unauthorizedSummary.top_headings?.length}
+				<ul class="top-headings">
+					{#each unauthorizedSummary.top_headings as item}
+						<li>{item.heading} <span class="badge badge-muted">{item.count}</span></li>
+					{/each}
+				</ul>
+			{/if}
+			<a class="btn-secondary" href="/admin/cataloging/authorities/corrections">
+				Open Batch Corrections
+			</a>
+		{:else}
+			<p class="muted">Loading unauthorized headings…</p>
+		{/if}
+	</section>
+</div>
+
+<style>
+	.container {
+		max-width: 1100px;
+		margin: 0 auto;
+		padding: 20px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.page-header h1 {
+		margin: 0 0 6px 0;
+	}
+
+	.page-header p {
+		margin: 0;
+		color: #555;
+	}
+
+	.card {
+		background: #fff;
+		border-radius: 8px;
+		padding: 20px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+	}
+
+	.search-grid {
+		display: grid;
+		grid-template-columns: 1fr 200px 160px;
+		gap: 10px;
+		align-items: center;
+	}
+
+	.search-grid input,
+	.search-grid select {
+		padding: 10px;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+	}
+
+	.btn-primary,
+	.btn-secondary {
+		padding: 10px 16px;
+		border: none;
+		border-radius: 6px;
+		font-weight: 600;
+		cursor: pointer;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+	}
+
+	.btn-primary {
+		background: #e73b42;
+		color: white;
+	}
+
+	.btn-secondary {
+		background: white;
+		color: #333;
+		border: 1px solid #ddd;
+	}
+
+	.message {
+		padding: 12px 16px;
+		border-radius: 6px;
+		margin-bottom: 8px;
+		border: 1px solid transparent;
+	}
+
+	.message.success {
+		background: #d4edda;
+		border-color: #c3e6cb;
+		color: #155724;
+	}
+
+	.message.error {
+		background: #f8d7da;
+		border-color: #f5c6cb;
+		color: #721c24;
+	}
+
+	.message.info {
+		background: #e7f1ff;
+		border-color: #d0e2ff;
+		color: #0b4f9c;
+	}
+
+	.results ul,
+	.top-headings {
+		list-style: none;
+		padding: 0;
+		margin: 12px 0 0 0;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.results li {
+		border: 1px solid #eee;
+		border-radius: 6px;
+		padding: 12px;
+	}
+
+	.heading-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.heading {
+		font-weight: 700;
+		color: #333;
+	}
+
+	.meta {
+		display: flex;
+		gap: 6px;
+		margin-top: 4px;
+	}
+
+	.variants {
+		margin-top: 6px;
+		color: #555;
+		font-size: 14px;
+	}
+
+	.badge {
+		display: inline-block;
+		padding: 3px 8px;
+		border-radius: 12px;
+		background: #e3f2fd;
+		color: #1976d2;
+		font-size: 12px;
+	}
+
+	.badge-muted {
+		background: #f1f1f1;
+		color: #444;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 12px;
+	}
+
+	.schedule-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: 10px;
+		align-items: center;
+	}
+
+	.schedule-grid label {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		font-weight: 600;
+	}
+
+	.schedule-grid select {
+		padding: 10px;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+	}
+
+	.checkbox {
+		flex-direction: row;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.bulk-downloads {
+		margin-top: 12px;
+		padding: 12px;
+		background: #f8f9fa;
+		border-radius: 6px;
+	}
+
+	.bulk-downloads ul {
+		list-style: none;
+		margin: 6px 0 0 0;
+		padding: 0;
+	}
+
+	.bulk-downloads li {
+		margin: 4px 0;
+	}
+
+	.coverage {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+		gap: 12px;
+		margin-bottom: 10px;
+	}
+
+	.stat {
+		background: #f8f9fa;
+		padding: 12px;
+		border-radius: 6px;
+		text-align: center;
+	}
+
+	.stat-value {
+		font-size: 28px;
+		font-weight: 700;
+		color: #e73b42;
+	}
+
+	.stat-label {
+		font-size: 12px;
+		color: #555;
+		text-transform: uppercase;
+		letter-spacing: 0.5px;
+	}
+
+	.muted {
+		color: #666;
+		font-size: 14px;
+	}
+
+	@media (max-width: 768px) {
+		.search-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.heading-row {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+	}
+</style>

--- a/src/routes/admin/cataloging/authorities/new/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/new/+page.svelte
@@ -1,0 +1,362 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+
+	const searchParams = $derived($page.url.searchParams);
+
+	let heading = $state(searchParams.get('heading') || '');
+	let type = $state(searchParams.get('type') || 'personal_name');
+	let source = $state('local');
+	let lccn = $state('');
+	let note = $state('');
+	let variantForms = $state<string[]>([]);
+	let crossReferences = $state<any[]>([]);
+	let message = $state('');
+	let messageType = $state<'success' | 'error' | 'info'>('info');
+	let saving = $state(false);
+
+	const authorityTypes = [
+		{ value: 'personal_name', label: 'Personal Name' },
+		{ value: 'corporate_name', label: 'Corporate Name' },
+		{ value: 'geographic_name', label: 'Geographic Name' },
+		{ value: 'topical_subject', label: 'Topical Subject' }
+	];
+
+	const sources = [
+		{ value: 'lcnaf', label: 'LC Names (LCNAF)' },
+		{ value: 'lcsh', label: 'LC Subjects (LCSH)' },
+		{ value: 'local', label: 'Local' }
+	];
+
+	function addVariant() {
+		variantForms = [...variantForms, ''];
+	}
+
+	function removeVariant(index: number) {
+		variantForms = variantForms.filter((_, i) => i !== index);
+	}
+
+	function addCrossRef() {
+		crossReferences = [
+			...crossReferences,
+			{ ref_type: 'see', reference_text: '', note: '' }
+		];
+	}
+
+	function removeCrossRef(index: number) {
+		crossReferences = crossReferences.filter((_, i) => i !== index);
+	}
+
+	async function createAuthority() {
+		saving = true;
+		message = '';
+
+		try {
+			const response = await fetch('/api/authorities', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					heading,
+					type,
+					source,
+					lccn: lccn || null,
+					note,
+					variant_forms: variantForms.filter((v) => v.trim()),
+					cross_references: crossReferences
+				})
+			});
+
+			if (!response.ok) {
+				const error = await response.json();
+				throw new Error(error.message || 'Failed to create authority');
+			}
+
+			const result = await response.json();
+			message = 'Authority created';
+			messageType = 'success';
+			setTimeout(() => goto(`/admin/cataloging/authorities/${result.authority.id}`), 900);
+		} catch (err: any) {
+			message = err.message || 'Failed to create authority';
+			messageType = 'error';
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New Authority</title>
+</svelte:head>
+
+<div class="container">
+	<header class="page-header">
+		<h1>Create Authority</h1>
+		<p>Add a new authorized heading with cross-references and variants.</p>
+	</header>
+
+	{#if message}
+		<div class="message {messageType}">
+			{message}
+		</div>
+	{/if}
+
+	<section class="card">
+		<div class="form-grid">
+			<label>
+				<span>Heading</span>
+				<input type="text" bind:value={heading} placeholder="Authorized heading" />
+			</label>
+
+			<label>
+				<span>Type</span>
+				<select bind:value={type}>
+					{#each authorityTypes as option}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			</label>
+
+			<label>
+				<span>Source</span>
+				<select bind:value={source}>
+					{#each sources as option}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			</label>
+
+			<label>
+				<span>LCCN (optional)</span>
+				<input type="text" bind:value={lccn} placeholder="n#######" />
+			</label>
+		</div>
+
+		<label>
+			<span>Note</span>
+			<textarea rows="3" bind:value={note} placeholder="Scope note or biographical note"></textarea>
+		</label>
+
+		<div class="section-header">
+			<h3>Variant Forms</h3>
+			<button class="btn-secondary" type="button" onclick={addVariant}>Add Variant</button>
+		</div>
+		{#if variantForms.length === 0}
+			<p class="muted">No variants yet.</p>
+		{:else}
+			<div class="variant-list">
+				{#each variantForms as variant, i}
+					<div class="variant-row">
+						<input type="text" bind:value={variantForms[i]} placeholder="Variant heading" />
+						<button class="btn-small" type="button" onclick={() => removeVariant(i)}>
+							Remove
+						</button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="section-header">
+			<h3>Cross References</h3>
+			<button class="btn-secondary" type="button" onclick={addCrossRef}>Add Reference</button>
+		</div>
+		{#if crossReferences.length === 0}
+			<p class="muted">Add "See" or "See also" references.</p>
+		{:else}
+			<div class="crossref-list">
+				{#each crossReferences as ref, i}
+					<div class="crossref-row">
+						<select bind:value={crossReferences[i].ref_type}>
+							<option value="see">See (Use)</option>
+							<option value="see_also">See also</option>
+							<option value="see_from">See from</option>
+						</select>
+						<input
+							type="text"
+							bind:value={crossReferences[i].reference_text}
+							placeholder="Reference heading"
+						/>
+						<input
+							type="text"
+							bind:value={crossReferences[i].note}
+							placeholder="Note (optional)"
+						/>
+						<button class="btn-small" type="button" onclick={() => removeCrossRef(i)}>
+							Remove
+						</button>
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="actions">
+			<button class="btn-primary" type="button" onclick={createAuthority} disabled={saving}>
+				{saving ? 'Saving…' : 'Create Authority'}
+			</button>
+			<a class="btn-secondary" href="/admin/cataloging/authorities">Cancel</a>
+		</div>
+	</section>
+</div>
+
+<style>
+	.container {
+		max-width: 960px;
+		margin: 0 auto;
+		padding: 20px;
+	}
+
+	.page-header {
+		margin-bottom: 20px;
+	}
+
+	.page-header h1 {
+		margin: 0 0 6px 0;
+	}
+
+	.page-header p {
+		margin: 0;
+		color: #555;
+	}
+
+	.card {
+		background: #fff;
+		border-radius: 8px;
+		padding: 20px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+	}
+
+	.form-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+		gap: 12px;
+		margin-bottom: 12px;
+	}
+
+	label {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		font-weight: 600;
+		color: #333;
+		font-size: 14px;
+	}
+
+	input,
+	select,
+	textarea {
+		padding: 10px;
+		border: 1px solid #ddd;
+		border-radius: 6px;
+		font-size: 14px;
+	}
+
+	textarea {
+		width: 100%;
+	}
+
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin: 16px 0 8px 0;
+	}
+
+	.variant-list,
+	.crossref-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.variant-row,
+	.crossref-row {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) auto;
+		gap: 8px;
+		align-items: center;
+	}
+
+	.actions {
+		display: flex;
+		gap: 10px;
+		margin-top: 16px;
+	}
+
+	.btn-primary,
+	.btn-secondary,
+	.btn-small {
+		padding: 10px 16px;
+		border: none;
+		border-radius: 6px;
+		font-weight: 600;
+		cursor: pointer;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+	}
+
+	.btn-primary {
+		background: #e73b42;
+		color: white;
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: white;
+		color: #333;
+		border: 1px solid #ddd;
+	}
+
+	.btn-small {
+		background: #f5f5f5;
+		color: #333;
+		border: 1px solid #ddd;
+		font-size: 13px;
+	}
+
+	.message {
+		padding: 12px 16px;
+		border-radius: 6px;
+		margin-bottom: 16px;
+		border: 1px solid transparent;
+	}
+
+	.message.success {
+		background: #d4edda;
+		border-color: #c3e6cb;
+		color: #155724;
+	}
+
+	.message.error {
+		background: #f8d7da;
+		border-color: #f5c6cb;
+		color: #721c24;
+	}
+
+	.message.info {
+		background: #e7f1ff;
+		border-color: #d0e2ff;
+		color: #0b4f9c;
+	}
+
+	.muted {
+		color: #666;
+		font-size: 14px;
+	}
+
+	@media (max-width: 768px) {
+		.variant-row,
+		.crossref-row {
+			grid-template-columns: 1fr;
+		}
+
+		.actions {
+			flex-direction: column;
+		}
+	}
+</style>

--- a/src/routes/admin/cataloging/authorities/reports/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/reports/+page.svelte
@@ -42,6 +42,9 @@
 	}
 
 	function calculateCoverage(): number {
+		if (unauthorized?.coverage !== undefined) {
+			return unauthorized.coverage;
+		}
 		if (!unauthorized || !stats) return 0;
 		const totalHeadings = stats.total + (unauthorized.total_unauthorized || 0);
 		if (totalHeadings === 0) return 100;

--- a/src/routes/admin/cataloging/edit/[id]/+page.server.ts
+++ b/src/routes/admin/cataloging/edit/[id]/+page.server.ts
@@ -12,7 +12,23 @@ export const load: PageServerLoad = async ({ params, locals: { supabase } }) => 
     throw error(404, 'Record not found');
   }
 
+  const { data: authorityLinks } = await supabase
+    .from('marc_authority_links')
+    .select(`
+      marc_field,
+      field_index,
+      confidence,
+      is_automatic,
+      authority:authority_id (
+        id,
+        heading,
+        source
+      )
+    `)
+    .eq('marc_record_id', params.id);
+
   return {
     record,
+    authorityLinks: authorityLinks || []
   };
 };

--- a/src/routes/api/authorities/loc/+server.ts
+++ b/src/routes/api/authorities/loc/+server.ts
@@ -78,7 +78,11 @@ export const GET: RequestHandler = async ({ url }) => {
 		return json({
 			authorities: authorities.filter((a) => a !== null),
 			count: authorities.length,
-			source: 'loc'
+			source: 'loc',
+			bulkDownloads: {
+				names: 'https://id.loc.gov/static/data/lcnaf.madsrdf.nt.gz',
+				subjects: 'https://id.loc.gov/static/data/authoritiessubjects.madsrdf.nt.gz'
+			}
 		});
 	} catch (err: any) {
 		console.error('Error searching LoC authorities:', err);

--- a/src/routes/api/authorities/loc/sync/+server.ts
+++ b/src/routes/api/authorities/loc/sync/+server.ts
@@ -1,0 +1,62 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * Schedule or trigger Library of Congress authority file synchronizations.
+ * Uses batch_jobs to track requested syncs (weekly/monthly).
+ */
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	const { frequency = 'weekly', scope = 'both', run_now = false } = await request.json();
+
+	if (!['weekly', 'monthly'].includes(frequency)) {
+		throw error(400, 'Frequency must be weekly or monthly');
+	}
+
+	if (!['names', 'subjects', 'both'].includes(scope)) {
+		throw error(400, 'Scope must be names, subjects, or both');
+	}
+
+	try {
+		const { data: job, error: jobError } = await supabase
+			.from('batch_jobs')
+			.insert({
+				job_type: 'authority_control',
+				job_name: `LoC authority sync (${frequency})`,
+				description: run_now
+					? 'Immediate Library of Congress authority sync'
+					: 'Scheduled Library of Congress authority sync',
+				parameters: { frequency, scope, run_now },
+				status: run_now ? 'running' : 'pending',
+				created_by: session.user.id,
+				started_at: run_now ? new Date().toISOString() : null
+			})
+			.select()
+			.single();
+
+		if (jobError) throw jobError;
+
+		// Provide bulk download references for operators who want offline sync
+		const bulkDownloads = {
+			names: 'https://id.loc.gov/static/data/lcnaf.madsrdf.nt.gz',
+			subjects: 'https://id.loc.gov/static/data/authoritiessubjects.madsrdf.nt.gz'
+		};
+
+		return json({
+			scheduled: true,
+			job,
+			bulkDownloads,
+			message: run_now
+				? 'Sync queued to run now. Monitor batch jobs for progress.'
+				: `Sync scheduled (${frequency}).`
+		});
+	} catch (err: any) {
+		console.error('Error scheduling LoC sync:', err);
+		if (err.status) throw err;
+		throw error(500, 'Failed to schedule Library of Congress sync');
+	}
+};

--- a/src/routes/api/authorities/merge/+server.ts
+++ b/src/routes/api/authorities/merge/+server.ts
@@ -1,0 +1,152 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+/**
+ * Merge duplicate authorities into a single canonical record.
+ * - Reassigns MARC links to the target authority
+ * - Moves cross-references
+ * - Merges variant forms (deduped)
+ */
+export const POST: RequestHandler = async ({ request, locals: { supabase, safeGetSession } }) => {
+	const { session } = await safeGetSession();
+	if (!session) {
+		throw error(401, 'Unauthorized');
+	}
+
+	const { source_id, target_id } = await request.json();
+
+	if (!source_id || !target_id) {
+		throw error(400, 'source_id and target_id are required');
+	}
+
+	if (source_id === target_id) {
+		throw error(400, 'Source and target authorities must be different');
+	}
+
+	try {
+		const [{ data: source }, { data: target }] = await Promise.all([
+			supabase.from('authorities').select('*').eq('id', source_id).single(),
+			supabase.from('authorities').select('*').eq('id', target_id).single()
+		]);
+
+		if (!source || !target) {
+			throw error(404, 'Authority not found');
+		}
+
+		// Merge variant forms and ensure the source heading is preserved as a variant
+		const mergedVariants = Array.from(
+			new Set(
+				[
+					...(target.variant_forms || []),
+					...(source.variant_forms || []),
+					source.heading !== target.heading ? source.heading : null
+				].filter(Boolean) as string[]
+			)
+		);
+
+		// Move cross references from source to target (deduping by ref_type + text)
+		const { data: targetRefs } = await supabase
+			.from('authority_cross_refs')
+			.select('ref_type, reference_text')
+			.eq('authority_id', target_id);
+
+		const existingRefKeys = new Set(
+			(targetRefs || []).map((ref: any) => `${ref.ref_type}:${ref.reference_text}`)
+		);
+
+		const { data: sourceRefs } = await supabase
+			.from('authority_cross_refs')
+			.select('*')
+			.eq('authority_id', source_id);
+
+		if (sourceRefs && sourceRefs.length > 0) {
+			const refsToMove = sourceRefs
+				.filter(
+					(ref) => !existingRefKeys.has(`${ref.ref_type}:${ref.reference_text}`)
+				)
+				.map((ref) => ({
+					ref_type: ref.ref_type,
+					reference_text: ref.reference_text,
+					related_authority_id: ref.related_authority_id,
+					note: ref.note,
+					authority_id: target_id
+				}));
+
+			if (refsToMove.length > 0) {
+				const { error: moveRefsError } = await supabase.from('authority_cross_refs').insert(refsToMove);
+				if (moveRefsError) throw moveRefsError;
+			}
+		}
+
+		// Reassign MARC authority links
+		const { data: sourceLinks } = await supabase
+			.from('marc_authority_links')
+			.select('*')
+			.eq('authority_id', source_id);
+
+		for (const link of sourceLinks || []) {
+			const { error: upsertError } = await supabase
+				.from('marc_authority_links')
+				.upsert(
+					{
+						marc_record_id: link.marc_record_id,
+						marc_field: link.marc_field,
+						field_index: link.field_index ?? 0,
+						authority_id: target_id,
+						is_automatic: link.is_automatic,
+						confidence: link.confidence,
+						created_by: link.created_by
+					},
+					{ onConflict: 'marc_record_id,marc_field,field_index' }
+				);
+
+			if (upsertError) throw upsertError;
+		}
+
+		// Update the target authority with merged variants
+		const { data: updatedTarget, error: updateError } = await supabase
+			.from('authorities')
+			.update({
+				variant_forms: mergedVariants,
+				updated_by: session.user.id
+			})
+			.eq('id', target_id)
+			.select()
+			.single();
+
+		if (updateError) throw updateError;
+
+		// Delete the source authority now that links and refs are moved
+		const { error: deleteError } = await supabase.from('authorities').delete().eq('id', source_id);
+		if (deleteError) throw deleteError;
+
+		// Log merge for both records
+		await supabase.from('authority_update_log').insert([
+			{
+				authority_id: target_id,
+				action: 'merged',
+				old_value: source,
+				new_value: updatedTarget,
+				performed_by: session.user.id,
+				note: `Merged authority ${source.heading} into ${target.heading}`
+			},
+			{
+				authority_id: source_id,
+				action: 'merged',
+				old_value: source,
+				new_value: { merged_into: target_id },
+				performed_by: session.user.id,
+				note: `Merged into ${target.heading}`
+			}
+		]);
+
+		return json({
+			merged: true,
+			target: updatedTarget
+		});
+	} catch (err: any) {
+		console.error('Error merging authorities:', err);
+		if (err.status) throw err;
+		throw error(500, 'Failed to merge authorities');
+	}
+};

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -6,6 +6,7 @@
 	import BookCover from '$lib/components/BookCover.svelte';
 	import QRCode from 'qrcode';
 	import { generateShortUrls, formatRecordsEmail, openMailto, canFitInEmail } from '$lib/utils/emailFormatter';
+	import AuthorityReferences from '$lib/components/AuthorityReferences.svelte';
 
 	let { data }: { data: PageData } = $props();
 
@@ -45,6 +46,12 @@
 	);
 
 	let queryDescription = $derived(getQueryDescription());
+	let authorityQueryTerm = $derived(
+		data.query.subject || data.query.author || data.query.q || ''
+	);
+	let authorityQueryType = $derived(
+		data.query.subject ? 'topical_subject' : data.query.author ? 'personal_name' : undefined
+	);
 
 	function getQueryDescription(): string {
 		const parts: string[] = [];
@@ -630,6 +637,10 @@
 			</div>
 		{/if}
 	</header>
+
+	{#if authorityQueryTerm}
+		<AuthorityReferences searchTerm={authorityQueryTerm} type={authorityQueryType} />
+	{/if}
 
 	<!-- Main Content Area -->
 	<div class="content-wrapper">


### PR DESCRIPTION
## Summary
- add admin flows for creating, editing, browsing, and importing authorities, including merge and scheduled Library of Congress sync tools
- extend authority APIs for field-aware unauthorized detection, single-record fetch with usage, merge handling, and batch-job scheduling for LCNAF/LCSH updates
- surface authority suggestions and cross-reference guidance in cataloging forms and OPAC search, document the authority schema tables, and fix the unauthorized-heading function migration drop

## Testing
- npm run check *(fails: existing Svelte a11y/state warnings in unrelated components)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69558822d1a48330938de415b26b348a)