### PR TITLE
Improve OPAC interface for library systems

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -43,6 +43,15 @@
 				<span>|</span>
 				<a href="/catalog/browse">Browse Collection</a>
 			</div>
+
+			<section class="catalog-info">
+				<h2>What's in this catalog?</h2>
+				<p>
+					This catalog contains bibliographic records for books, serials, audiovisual materials, and electronic resources.
+					Use the search box above to find items by title, author, subject headings, or ISBN.
+					Advanced search options allow for more precise queries using multiple criteria.
+				</p>
+			</section>
 		</div>
 	</header>
 
@@ -200,6 +209,31 @@
 	.search-links span {
 		opacity: 0.3;
 		color: #888;
+	}
+
+	.catalog-info {
+		max-width: 700px;
+		width: 100%;
+		margin: 3rem auto 0;
+		padding: 2rem;
+		background: rgba(255, 255, 255, 0.03);
+		border-radius: var(--radius-md);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+	}
+
+	.catalog-info h2 {
+		font-size: 1.125rem;
+		color: rgba(255, 255, 255, 0.6);
+		margin: 0 0 1rem 0;
+		font-weight: 500;
+		text-transform: none;
+	}
+
+	.catalog-info p {
+		color: rgba(255, 255, 255, 0.5);
+		font-size: 0.95rem;
+		line-height: 1.6;
+		margin: 0;
 	}
 
 	.homepage-content {

--- a/src/routes/catalog/browse/+page.svelte
+++ b/src/routes/catalog/browse/+page.svelte
@@ -1,223 +1,583 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
 
 	let { data }: { data: PageData } = $props();
 
-	let records = $state<any[]>([]);
+	let browseMode = $state<'subjects' | 'authors' | 'call_numbers'>('subjects');
+	let selectedLetter = $state<string | null>(null);
+	let searchFilter = $state('');
+	let headings = $state<Array<{ heading: string; count: number }>>([]);
 	let loading = $state(true);
+	let expandedHeading = $state<string | null>(null);
+	let headingTitles = $state<any[]>([]);
+	let loadingTitles = $state(false);
+
+	const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 	onMount(async () => {
-		const { data: recordsData } = await data.supabase
-			.from('marc_records')
-			.select('*')
-			.order('title_statement->a');
+		await loadHeadings();
+	});
 
-		records = recordsData || [];
-		loading = false;
+	async function loadHeadings() {
+		loading = true;
+		headings = [];
+
+		try {
+			if (browseMode === 'subjects') {
+				// Get all subject headings from marc_records
+				const { data: records } = await data.supabase
+					.from('marc_records')
+					.select('subject_topical');
+
+				// Extract and count subject headings
+				const subjectCounts = new Map<string, number>();
+				records?.forEach(record => {
+					if (record.subject_topical && Array.isArray(record.subject_topical)) {
+						record.subject_topical.forEach((subject: any) => {
+							if (subject.a) {
+								const heading = subject.a;
+								subjectCounts.set(heading, (subjectCounts.get(heading) || 0) + 1);
+							}
+						});
+					}
+				});
+
+				// Convert to array and sort
+				headings = Array.from(subjectCounts.entries())
+					.map(([heading, count]) => ({ heading, count }))
+					.sort((a, b) => a.heading.localeCompare(b.heading));
+			} else if (browseMode === 'authors') {
+				// Get all author names from marc_records
+				const { data: records } = await data.supabase
+					.from('marc_records')
+					.select('main_entry_personal_name');
+
+				// Extract and count authors
+				const authorCounts = new Map<string, number>();
+				records?.forEach(record => {
+					if (record.main_entry_personal_name?.a) {
+						const heading = record.main_entry_personal_name.a;
+						authorCounts.set(heading, (authorCounts.get(heading) || 0) + 1);
+					}
+				});
+
+				// Convert to array and sort
+				headings = Array.from(authorCounts.entries())
+					.map(([heading, count]) => ({ heading, count }))
+					.sort((a, b) => a.heading.localeCompare(b.heading));
+			}
+		} catch (error) {
+			console.error('Error loading headings:', error);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function expandHeading(heading: string) {
+		if (expandedHeading === heading) {
+			expandedHeading = null;
+			headingTitles = [];
+			return;
+		}
+
+		expandedHeading = heading;
+		loadingTitles = true;
+
+		try {
+			if (browseMode === 'subjects') {
+				// Find all records with this subject
+				const { data: records } = await data.supabase
+					.from('marc_records')
+					.select('id, title_statement, main_entry_personal_name, publication_info, material_type, isbn')
+					.contains('subject_topical', [{ a: heading }]);
+
+				headingTitles = records || [];
+			} else if (browseMode === 'authors') {
+				// Find all records by this author
+				const { data: records } = await data.supabase
+					.from('marc_records')
+					.select('id, title_statement, main_entry_personal_name, publication_info, material_type, isbn')
+					.eq('main_entry_personal_name->>a', heading);
+
+				headingTitles = records || [];
+			}
+		} catch (error) {
+			console.error('Error loading titles:', error);
+		} finally {
+			loadingTitles = false;
+		}
+	}
+
+	function changeBrowseMode(mode: 'subjects' | 'authors' | 'call_numbers') {
+		browseMode = mode;
+		selectedLetter = null;
+		searchFilter = '';
+		expandedHeading = null;
+		headingTitles = [];
+		loadHeadings();
+	}
+
+	function filterByLetter(letter: string | null) {
+		selectedLetter = letter;
+	}
+
+	const filteredHeadings = $derived(() => {
+		let result = headings;
+
+		// Filter by selected letter
+		if (selectedLetter) {
+			result = result.filter(h => h.heading.toUpperCase().startsWith(selectedLetter!));
+		}
+
+		// Filter by search term
+		if (searchFilter) {
+			result = result.filter(h =>
+				h.heading.toLowerCase().includes(searchFilter.toLowerCase())
+			);
+		}
+
+		return result;
 	});
 </script>
 
 <div class="browse-page">
 	<header class="page-header">
-		<h1>Browse Collection</h1>
-		<a href="/" class="back-link">← Back to Search</a>
+		<div class="header-top">
+			<a href="/catalog" class="back-link">← Back to Catalog</a>
+		</div>
+		<h1>Browse</h1>
+		<p class="subtitle">Explore by subject headings, authors, and other catalog structures.</p>
 	</header>
 
-	{#if loading}
-		<p class="loading">Loading...</p>
-	{:else if records.length === 0}
-		<div class="empty">
-			<p>No records in the catalog yet.</p>
-		</div>
-	{:else}
-		<div class="records-list">
-			{#each records as record}
-				<article class="record-card">
-					<div class="record-content">
-						<h3>
-							<a href="/catalog/record/{record.id}">{record.title_statement?.a || 'Untitled'}</a>
-						</h3>
-						{#if record.title_statement?.b}
-							<p class="subtitle">{record.title_statement.b}</p>
-						{/if}
-						{#if record.main_entry_personal_name?.a}
-							<p class="author">
-								by <a
-									href="/catalog/search/results?author={encodeURIComponent(
-										record.main_entry_personal_name.a
-									)}"
-									class="author-link">{record.main_entry_personal_name.a}</a
-								>
-							</p>
-						{/if}
-						{#if record.publication_info?.b || record.publication_info?.c}
-							<p class="publication">
-								{#if record.publication_info.b}{record.publication_info.b}{/if}
-								{#if record.publication_info.c}
-									{#if record.publication_info.b}, {/if}{record.publication_info.c}
-								{/if}
-							</p>
-						{/if}
-						{#if record.series_statement?.a}
-							<p class="series">
-								Series: <a
-									href="/catalog/search/results?q={encodeURIComponent(record.series_statement.a)}"
-									class="series-link">{record.series_statement.a}</a
-								>
-								{#if record.series_statement?.v}; {record.series_statement.v}{/if}
-							</p>
-						{/if}
-						<div class="badges">
-							{#if record.material_type}
-								<span class="badge type">{record.material_type}</span>
-							{/if}
-						</div>
-					</div>
-				</article>
+	<div class="browse-modes">
+		<button
+			class="mode-btn"
+			class:active={browseMode === 'subjects'}
+			onclick={() => changeBrowseMode('subjects')}
+		>
+			Subject Headings
+		</button>
+		<button
+			class="mode-btn"
+			class:active={browseMode === 'authors'}
+			onclick={() => changeBrowseMode('authors')}
+		>
+			Authors
+		</button>
+		<button
+			class="mode-btn disabled"
+			class:active={browseMode === 'call_numbers'}
+			disabled
+		>
+			Call Numbers
+		</button>
+	</div>
+
+	<div class="browse-content">
+		<div class="alphabet-nav">
+			<button
+				class="letter-btn"
+				class:active={selectedLetter === null}
+				onclick={() => filterByLetter(null)}
+			>
+				All
+			</button>
+			{#each alphabet as letter}
+				<button
+					class="letter-btn"
+					class:active={selectedLetter === letter}
+					onclick={() => filterByLetter(letter)}
+				>
+					{letter}
+				</button>
 			{/each}
 		</div>
-	{/if}
+
+		<div class="search-filter">
+			<input
+				type="search"
+				bind:value={searchFilter}
+				placeholder="Filter {browseMode === 'subjects' ? 'subjects' : 'authors'}..."
+			/>
+		</div>
+
+		{#if loading}
+			<div class="loading-state">
+				<p>Loading headings...</p>
+			</div>
+		{:else if filteredHeadings().length === 0}
+			<div class="empty-state">
+				<p>No headings found.</p>
+			</div>
+		{:else}
+			<div class="headings-list">
+				<p class="headings-count">
+					{filteredHeadings().length} heading{filteredHeadings().length === 1 ? '' : 's'}
+					{selectedLetter ? `starting with ${selectedLetter}` : ''}
+				</p>
+
+				{#each filteredHeadings() as { heading, count }}
+					<div class="heading-item">
+						<button
+							class="heading-button"
+							class:expanded={expandedHeading === heading}
+							onclick={() => expandHeading(heading)}
+						>
+							<div class="heading-content">
+								<span class="heading-text">{heading}</span>
+								<span class="heading-count">{count} title{count === 1 ? '' : 's'}</span>
+							</div>
+							<svg
+								width="20"
+								height="20"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								style="transform: rotate({expandedHeading === heading ? '90deg' : '0deg'}); transition: transform 0.2s;"
+							>
+								<polyline points="9 18 15 12 9 6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+							</svg>
+						</button>
+
+						{#if expandedHeading === heading}
+							<div class="titles-list">
+								{#if loadingTitles}
+									<p class="loading-titles">Loading titles...</p>
+								{:else if headingTitles.length === 0}
+									<p class="no-titles">No titles found.</p>
+								{:else}
+									{#each headingTitles as title}
+										<div class="title-item">
+											<a href="/catalog/record/{title.id}" class="title-link">
+												{title.title_statement?.a || 'Untitled'}
+											</a>
+											{#if title.main_entry_personal_name?.a}
+												<p class="title-author">by {title.main_entry_personal_name.a}</p>
+											{/if}
+											{#if title.publication_info?.c}
+												<p class="title-year">({title.publication_info.c})</p>
+											{/if}
+											{#if title.material_type}
+												<span class="material-badge">{title.material_type}</span>
+											{/if}
+										</div>
+									{/each}
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
 </div>
 
 <style>
 	.browse-page {
-		min-height: 100vh;
-		padding: 2rem;
 		max-width: 1200px;
 		margin: 0 auto;
+		padding: 2rem;
+		min-height: 100vh;
 	}
 
 	.page-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
 		margin-bottom: 2rem;
 	}
 
-	h1 {
-		margin: 0;
+	.header-top {
+		margin-bottom: 1rem;
 	}
 
 	.back-link {
-		color: var(--accent);
+		color: #667eea;
 		text-decoration: none;
+		font-size: 0.95rem;
 	}
 
 	.back-link:hover {
 		text-decoration: underline;
 	}
 
-	.loading,
-	.empty {
-		text-align: center;
-		padding: 3rem;
-		color: var(--text-muted);
-	}
-
-	.records-list {
-		display: flex;
-		flex-direction: column;
-		gap: 1.5rem;
-	}
-
-	.record-card {
-		background: white;
-		padding: 1.5rem;
-		border: 1px solid #e0e0e0;
-		border-radius: 8px;
-		transition: all 0.2s;
-	}
-
-	.record-card:hover {
-		border-color: #667eea;
-		box-shadow: 0 2px 8px rgba(102, 126, 234, 0.1);
-	}
-
-	.record-content {
-		min-width: 0;
-	}
-
-	.record-content h3 {
+	h1 {
 		margin: 0 0 0.5rem 0;
-		font-size: 1.25rem;
-	}
-
-	.record-content h3 a {
+		font-size: 2rem;
 		color: #2c3e50;
-		text-decoration: none;
-	}
-
-	.record-content h3 a:hover {
-		color: #667eea;
-		text-decoration: underline;
 	}
 
 	.subtitle {
-		margin: 0 0 0.5rem 0;
+		margin: 0;
 		color: #666;
-		font-style: italic;
 		font-size: 1rem;
 	}
 
-	.author {
-		margin: 0 0 0.5rem 0;
-		color: #333;
-		font-size: 0.875rem;
+	.browse-modes {
+		display: flex;
+		gap: 0.5rem;
+		margin-bottom: 2rem;
+		border-bottom: 2px solid #e0e0e0;
+		padding-bottom: 0;
 	}
 
-	.author-link {
+	.mode-btn {
+		padding: 0.75rem 1.5rem;
+		background: transparent;
+		border: none;
+		border-bottom: 3px solid transparent;
+		cursor: pointer;
+		font-size: 0.95rem;
+		font-weight: 500;
+		color: #666;
+		transition: all 0.2s;
+		margin-bottom: -2px;
+	}
+
+	.mode-btn:hover:not(.disabled) {
 		color: #667eea;
-		text-decoration: none;
-		transition: color 0.2s;
+		border-bottom-color: #c5cae9;
 	}
 
-	.author-link:hover {
-		color: #5568d3;
-		text-decoration: underline;
+	.mode-btn.active {
+		color: #667eea;
+		border-bottom-color: #667eea;
 	}
 
-	.publication {
-		margin: 0 0 0.5rem 0;
+	.mode-btn.disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.alphabet-nav {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.375rem;
+		margin-bottom: 1.5rem;
+		padding: 1rem;
+		background: #f8f9fa;
+		border-radius: 8px;
+	}
+
+	.letter-btn {
+		width: 36px;
+		height: 36px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: white;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: #666;
+		transition: all 0.2s;
+	}
+
+	.letter-btn:hover {
+		border-color: #667eea;
+		color: #667eea;
+	}
+
+	.letter-btn.active {
+		background: #667eea;
+		color: white;
+		border-color: #667eea;
+	}
+
+	.search-filter {
+		margin-bottom: 1.5rem;
+	}
+
+	.search-filter input {
+		width: 100%;
+		padding: 0.875rem 1rem;
+		border: 1px solid #ddd;
+		border-radius: 8px;
+		font-size: 1rem;
+		box-sizing: border-box;
+	}
+
+	.search-filter input:focus {
+		outline: none;
+		border-color: #667eea;
+	}
+
+	.loading-state,
+	.empty-state {
+		text-align: center;
+		padding: 4rem 2rem;
+		color: #999;
+	}
+
+	.headings-count {
+		margin: 0 0 1rem 0;
 		color: #666;
 		font-size: 0.875rem;
+		padding: 0 0.5rem;
 	}
 
-	.series {
-		margin: 0 0 0.5rem 0;
-		color: #333;
+	.headings-list {
+		background: white;
+		border: 1px solid #e0e0e0;
+		border-radius: 8px;
+		overflow: hidden;
+	}
+
+	.heading-item {
+		border-bottom: 1px solid #f0f0f0;
+	}
+
+	.heading-item:last-child {
+		border-bottom: none;
+	}
+
+	.heading-button {
+		width: 100%;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 1rem 1.5rem;
+		background: white;
+		border: none;
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.2s;
+	}
+
+	.heading-button:hover {
+		background: #fafafa;
+	}
+
+	.heading-button.expanded {
+		background: #f8f9fa;
+	}
+
+	.heading-content {
+		flex: 1;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.heading-text {
+		font-size: 1rem;
+		font-weight: 500;
+		color: #2c3e50;
+	}
+
+	.heading-count {
+		font-size: 0.875rem;
+		color: #999;
+		white-space: nowrap;
+	}
+
+	.heading-button svg {
+		flex-shrink: 0;
+		color: #999;
+	}
+
+	.titles-list {
+		padding: 1rem 1.5rem 1.5rem;
+		background: #fafafa;
+		border-top: 1px solid #e8e8e8;
+	}
+
+	.loading-titles,
+	.no-titles {
+		margin: 0;
+		padding: 1rem;
+		text-align: center;
+		color: #999;
 		font-size: 0.875rem;
 	}
 
-	.series-link {
+	.title-item {
+		padding: 0.875rem;
+		background: white;
+		border: 1px solid #e8e8e8;
+		border-radius: 4px;
+		margin-bottom: 0.75rem;
+	}
+
+	.title-item:last-child {
+		margin-bottom: 0;
+	}
+
+	.title-link {
+		display: block;
 		color: #667eea;
 		text-decoration: none;
 		font-weight: 500;
-		transition: color 0.2s;
+		font-size: 1rem;
+		margin-bottom: 0.25rem;
 	}
 
-	.series-link:hover {
-		color: #5568d3;
+	.title-link:hover {
 		text-decoration: underline;
+		color: #5568d3;
 	}
 
-	.badges {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
-		margin-top: 0.75rem;
+	.title-author {
+		margin: 0.25rem 0 0 0;
+		color: #666;
+		font-size: 0.875rem;
+		font-style: italic;
 	}
 
-	.badge {
+	.title-year {
+		display: inline;
+		margin: 0 0 0 0.5rem;
+		color: #999;
+		font-size: 0.875rem;
+	}
+
+	.material-badge {
 		display: inline-block;
-		padding: 0.25rem 0.75rem;
+		padding: 0.25rem 0.625rem;
+		background: #e3f2fd;
+		color: #1976d2;
 		border-radius: 12px;
 		font-size: 0.75rem;
 		font-weight: 500;
+		margin-top: 0.5rem;
 	}
 
-	.badge.type {
-		background: #e3f2fd;
-		color: #1976d2;
+	@media (max-width: 768px) {
+		.browse-page {
+			padding: 1rem;
+		}
+
+		h1 {
+			font-size: 1.5rem;
+		}
+
+		.alphabet-nav {
+			gap: 0.25rem;
+		}
+
+		.letter-btn {
+			width: 32px;
+			height: 32px;
+			font-size: 0.8125rem;
+		}
+
+		.heading-button {
+			padding: 0.875rem 1rem;
+		}
+
+		.heading-text {
+			font-size: 0.95rem;
+		}
+
+		.heading-count {
+			font-size: 0.8125rem;
+		}
+
+		.titles-list {
+			padding: 1rem;
+		}
 	}
 </style>

--- a/src/routes/catalog/record/[id]/+page.svelte
+++ b/src/routes/catalog/record/[id]/+page.svelte
@@ -10,6 +10,7 @@
 
 	let copyingLink = $state(false);
 	let showCopiedToast = $state(false);
+	let showMarcRecord = $state(false);
 
 	// Helper function to get relationship label
 	function getRelationshipLabel(type: string): string {
@@ -310,6 +311,20 @@
 						</div>
 					</section>
 				{/if}
+
+				<section class="info-section marc-section">
+					<button class="marc-toggle" onclick={() => showMarcRecord = !showMarcRecord}>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" style="transform: rotate({showMarcRecord ? '90deg' : '0deg'}); transition: transform 0.2s;">
+							<polyline points="9 18 15 12 9 6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+						</svg>
+						View MARC Record
+					</button>
+					{#if showMarcRecord}
+						<div class="marc-display">
+							<pre>{JSON.stringify(record, null, 2)}</pre>
+						</div>
+					{/if}
+				</section>
 			</div>
 
 			<aside class="sidebar">
@@ -597,6 +612,55 @@
 		font-size: 0.875rem;
 		color: #666;
 		font-style: italic;
+	}
+
+	.marc-section {
+		border: 1px solid #e0e0e0;
+		padding: 0;
+		overflow: hidden;
+	}
+
+	.marc-toggle {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 1rem 1.5rem;
+		background: #f8f9fa;
+		border: none;
+		cursor: pointer;
+		font-size: 0.95rem;
+		font-weight: 500;
+		color: #666;
+		transition: all 0.2s;
+		text-align: left;
+	}
+
+	.marc-toggle:hover {
+		background: #eef0f2;
+		color: #667eea;
+	}
+
+	.marc-toggle svg {
+		flex-shrink: 0;
+	}
+
+	.marc-display {
+		padding: 1.5rem;
+		background: #fafafa;
+		border-top: 1px solid #e0e0e0;
+		max-height: 500px;
+		overflow-y: auto;
+	}
+
+	.marc-display pre {
+		margin: 0;
+		font-family: 'Courier New', Courier, monospace;
+		font-size: 0.85rem;
+		line-height: 1.5;
+		color: #333;
+		white-space: pre-wrap;
+		word-wrap: break-word;
 	}
 
 	.sidebar {

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -25,6 +25,7 @@
 	let generatingShortUrl = $state(false);
 	let selectedRecords = $state<string[]>([]);
 	let emailingRecords = $state(false);
+	let showCovers = $state(true);
 	let exportFields = $state({
 		title: true,
 		author: true,
@@ -691,6 +692,15 @@
 							<option value="date_old">Oldest First</option>
 						</select>
 					</div>
+					<div class="left-controls">
+						<button
+							class="toggle-covers-btn"
+							onclick={() => showCovers = !showCovers}
+							aria-label={showCovers ? 'Hide covers' : 'Show covers'}
+						>
+							{showCovers ? 'Hide Covers' : 'Show Covers'}
+						</button>
+					</div>
 					<div class="view-controls">
 						<span class="results-range"
 							>Showing {startResult}-{endResult} of {data.total.toLocaleString()}</span
@@ -750,7 +760,7 @@
 				<!-- Results List -->
 				<div class="results-list">
 					{#each data.results as record}
-						<article class="result-card" class:selected={selectedRecords.includes(record.id)}>
+						<article class="result-card" class:selected={selectedRecords.includes(record.id)} class:no-cover={!showCovers}>
 							<div class="result-checkbox">
 								<input
 									type="checkbox"
@@ -760,9 +770,11 @@
 									aria-label="Select {record.title_statement?.a || 'Untitled'}"
 								/>
 							</div>
-							<div class="result-cover">
-								<BookCover isbn={record.isbn} size="medium" />
-							</div>
+							{#if showCovers}
+								<div class="result-cover">
+									<BookCover isbn={record.isbn} size="medium" />
+								</div>
+							{/if}
 							<div class="result-content">
 								<h3>
 									<a href="/catalog/record/{record.id}">
@@ -1600,17 +1612,39 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		margin-bottom: 1.5rem;
-		padding: 1rem;
-		background: white;
-		border-radius: 8px;
-		border: 1px solid #e0e0e0;
+		margin-bottom: 0;
+		padding: 1rem 1.5rem;
+		background: #fafafa;
+		border-top: 1px solid #e0e0e0;
+		border-bottom: 1px solid #e0e0e0;
 	}
 
 	.sort-controls {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
+	}
+
+	.left-controls {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.toggle-covers-btn {
+		padding: 0.5rem 1rem;
+		background: white;
+		color: #666;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		font-size: 0.875rem;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.toggle-covers-btn:hover {
+		border-color: #667eea;
+		color: #667eea;
 	}
 
 	.sort-controls label {
@@ -1689,29 +1723,35 @@
 	.results-list {
 		display: flex;
 		flex-direction: column;
-		gap: 1.5rem;
+		gap: 0;
 	}
 
 	.result-card {
 		display: grid;
 		grid-template-columns: 40px 120px 1fr;
 		gap: 1.5rem;
-		padding: 1.5rem;
+		padding: 1.25rem 1.5rem;
 		background: white;
-		border-radius: 8px;
-		border: 1px solid #e0e0e0;
-		transition: all 0.2s;
+		border-bottom: 1px solid #e8e8e8;
+		transition: background-color 0.15s;
+	}
+
+	.result-card.no-cover {
+		grid-template-columns: 40px 1fr;
+	}
+
+	.result-card:first-child {
+		border-top: 1px solid #e8e8e8;
 	}
 
 	.result-card:hover {
-		border-color: #667eea;
-		box-shadow: 0 2px 8px rgba(102, 126, 234, 0.1);
+		background: #fafafa;
 	}
 
 	.result-card.selected {
-		border-color: #e73b42;
 		background: #fff5f5;
-		box-shadow: 0 2px 8px rgba(231, 59, 66, 0.15);
+		border-left: 3px solid #e73b42;
+		padding-left: calc(1.5rem - 3px);
 	}
 
 	.result-checkbox {
@@ -2179,7 +2219,11 @@
 		.result-card {
 			grid-template-columns: 30px 80px 1fr;
 			gap: 1rem;
-			padding: 1rem;
+			padding: 1rem 0.75rem;
+		}
+
+		.result-card.no-cover {
+			grid-template-columns: 30px 1fr;
 		}
 
 		.result-checkbox input[type="checkbox"] {


### PR DESCRIPTION
Implements comprehensive UX improvements focused on clarity, structural honesty, and authority-forward browsing:

**Landing Page:**
- Add "What's in this catalog?" section with visually secondary styling
- Explains catalog contents and search capabilities

**Search Results:**
- Refactor to list-based layout (reduced card-like styling)
- Add "Show/Hide Covers" toggle for bibliographic focus
- Remove heavy borders and shadows for cleaner appearance
- Emphasize title, author, publication info, and material type

**Individual Record Page:**
- Add collapsible "View MARC Record" section
- Maintain human-readable field labels (no MARC field numbers)
- Subjects displayed as linked authority headings

**Browse Page:**
- Complete rewrite with authority-based Subject Headings as default
- Display headings as authority entries with result counts
- A-Z navigation and typeahead filtering
- No covers at authority level (covers only in expanded titles)
- Support for browsing by Subjects and Authors
- Clicking heading expands to show related titles

**MARC Integrity:**
- All internal field mappings preserved
- No changes to database queries or MARC storage
- Human-readable labels used throughout UI
- MARC data accessible via collapsible View MARC option

All changes maintain existing functionality while providing a more professional, library-focused user experience.