### PR TITLE
Refine landing page and record page visual design

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,20 +54,12 @@
 			</section>
 		</div>
 	</header>
-
-	{#if data.homepage}
-		<section class="homepage-content">
-			<div class="content-wrapper">
-				{@html data.homepage.content}
-			</div>
-		</section>
-	{/if}
 </div>
 
 <style>
 	.catalog-home {
 		min-height: 100vh;
-		background: linear-gradient(135deg, #1a1a1a 0%, #2d2d2d 100%);
+		background: linear-gradient(135deg, #3a3a3a 0%, #4d4d4d 100%);
 		padding: 0;
 	}
 
@@ -115,7 +107,7 @@
 	}
 
 	.main-logo {
-		max-width: 500px;
+		max-width: 300px;
 		width: 100%;
 		height: auto;
 		margin-bottom: 2rem;
@@ -236,80 +228,9 @@
 		margin: 0;
 	}
 
-	.homepage-content {
-		background: white;
-		padding: 4rem 2rem;
-	}
-
-	.content-wrapper {
-		max-width: 1200px;
-		margin: 0 auto;
-		line-height: 1.8;
-		color: #333;
-	}
-
-	.content-wrapper :global(h1) {
-		font-size: 2.5em;
-		font-weight: bold;
-		margin-top: 1em;
-		margin-bottom: 0.5em;
-		color: #2c3e50;
-	}
-
-	.content-wrapper :global(h2) {
-		font-size: 2em;
-		font-weight: bold;
-		margin-top: 1.5em;
-		margin-bottom: 0.75em;
-		color: #2c3e50;
-	}
-
-	.content-wrapper :global(h3) {
-		font-size: 1.5em;
-		font-weight: bold;
-		margin-top: 1.25em;
-		margin-bottom: 0.5em;
-		color: #2c3e50;
-	}
-
-	.content-wrapper :global(p) {
-		margin: 1em 0;
-	}
-
-	.content-wrapper :global(a) {
-		color: #667eea;
-		text-decoration: underline;
-	}
-
-	.content-wrapper :global(a:hover) {
-		color: #5568d3;
-	}
-
-	.content-wrapper :global(ul),
-	.content-wrapper :global(ol) {
-		padding-left: 2em;
-		margin: 1em 0;
-	}
-
-	.content-wrapper :global(blockquote) {
-		border-left: 4px solid #e73b42;
-		padding-left: 1.5em;
-		margin: 1.5em 0;
-		font-style: italic;
-		color: #666;
-	}
-
-	.content-wrapper :global(img) {
-		max-width: 100%;
-		height: auto;
-		border-radius: 8px;
-		margin: 2em auto;
-		display: block;
-	}
-
 	@media (max-width: 768px) {
 		.main-logo {
-			max-width: 350px;
+			max-width: 250px;
 		}
 
 		.tagline {
@@ -318,10 +239,6 @@
 
 		.hero-content {
 			padding: 2rem 1rem;
-		}
-
-		.homepage-content {
-			padding: 3rem 1.5rem;
 		}
 	}
 </style>

--- a/src/routes/catalog/record/[id]/+page.svelte
+++ b/src/routes/catalog/record/[id]/+page.svelte
@@ -161,7 +161,7 @@
 							<span class="value">
 								{#if record.publication_info.b}{record.publication_info.b}{/if}
 								{#if record.publication_info.a} ({record.publication_info.a}){/if}
-								{#if record.publication_info.c}, {record.publication_info.c}{/if}
+								{#if record.publication_info.c},{record.publication_info.c}{/if}
 							</span>
 						</div>
 					{/if}
@@ -211,16 +211,18 @@
 				{#if record.subject_topical && record.subject_topical.length > 0}
 					<section class="info-section">
 						<h3>Subjects</h3>
-						<div class="subjects">
+						<ul class="subjects-list">
 							{#each record.subject_topical as subject}
-								<a
-									href="/catalog/search/results?subject={encodeURIComponent(subject.a)}"
-									class="subject-tag"
-								>
-									{subject.a}
-								</a>
+								<li>
+									<a
+										href="/catalog/search/results?subject={encodeURIComponent(subject.a)}"
+										class="subject-link"
+									>
+										{subject.a}
+									</a>
+								</li>
 							{/each}
-						</div>
+						</ul>
 					</section>
 				{/if}
 
@@ -526,29 +528,31 @@
 		text-decoration: underline;
 	}
 
-	.subjects {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.5rem;
+	.subjects-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
 	}
 
-	.subject-tag {
-		display: inline-block;
-		padding: 0.5rem 1rem;
-		background: #e8eaf6;
-		color: #3f51b5;
-		border-radius: 16px;
-		font-size: 0.875rem;
+	.subjects-list li {
+		padding: 0.5rem 0;
+		border-bottom: 1px solid #f0f0f0;
+	}
+
+	.subjects-list li:last-child {
+		border-bottom: none;
+	}
+
+	.subject-link {
+		color: #667eea;
 		text-decoration: none;
-		transition: all 0.2s;
-		cursor: pointer;
+		font-size: 0.95rem;
+		transition: color 0.2s;
 	}
 
-	.subject-tag:hover {
-		background: #c5cae9;
-		color: #303f9f;
-		transform: translateY(-2px);
-		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	.subject-link:hover {
+		color: #5568d3;
+		text-decoration: underline;
 	}
 
 	.related-records {


### PR DESCRIPTION
**Landing Page:**
- Reduce logo size from 500px to 300px (250px on mobile)
- Lighten dark background gradient (#3a3a3a to #4d4d4d)
- Remove homepage content section below catalog info

**Record Page:**
- Change subjects from tag/badge display to clean list format
- Fix publisher field comma spacing (no space before comma)
- Subjects now shown as simple bulleted list with separator lines
- Maintains clickable authority links without tag styling