### PR TITLE
Fix authority control and attachment issues

### DIFF
--- a/src/routes/admin/cataloging/authorities/import/+page.svelte
+++ b/src/routes/admin/cataloging/authorities/import/+page.svelte
@@ -158,7 +158,14 @@
 						<li>
 							<div class="heading-row">
 								<div>
-									<div class="heading">{authority.label || authority.heading}</div>
+									<div class="heading">
+										{authority.label || authority.heading}
+										{#if authority.uri}
+											<a href={authority.uri} target="_blank" rel="noopener noreferrer" class="loc-link" title="View at Library of Congress">
+												🔗
+											</a>
+										{/if}
+									</div>
 									<div class="meta">
 										{#if authority.lccn}<span class="badge">LCCN {authority.lccn}</span>{/if}
 										<span class="badge">{type === 'subjects' ? 'LCSH' : 'LCNAF'}</span>
@@ -476,6 +483,18 @@
 	.muted {
 		color: #666;
 		font-size: 14px;
+	}
+
+	.loc-link {
+		margin-left: 8px;
+		text-decoration: none;
+		font-size: 16px;
+		opacity: 0.7;
+		transition: opacity 0.2s;
+	}
+
+	.loc-link:hover {
+		opacity: 1;
 	}
 
 	@media (max-width: 768px) {

--- a/src/routes/admin/cataloging/edit/[id]/+page.svelte
+++ b/src/routes/admin/cataloging/edit/[id]/+page.svelte
@@ -675,7 +675,6 @@ function statusClass(status: string) {
 						type="url"
 						bind:value={attachmentForm.external_url}
 						placeholder="https://provider.com/share/..."
-						required
 					/>
 				</div>
 


### PR DESCRIPTION
Authority Control Improvements:
- Enhanced LoC JSON-LD parsing to find resources with proper labels
- Added check for madsrdf:authoritativeLabel field (common in LoC data)
- Filter resources by presence of valid label fields before selection
- Prevent blank node IDs from being displayed as authority headings
- Fixed "Authority not found" 404 errors during LoC import

Authority Display:
- Added clickable link icon (🔗) to view authority at Library of Congress
- Links open in new tab with proper rel attributes
- Added hover styling for better UX

Record Editing:
- Removed "required" attribute from attachment external URL field
- Users can now save record edits without adding attachments
- Attachments remain optional as intended

These fixes resolve issues where:
- LoC authorities showed as random strings like "_:b94iddOtlocdOtgovauthoritiessubjectssh2015000779"
- Local authority creation failed with 404 errors
- Record editing was blocked by attachment field validation
- Users couldn't access LoC authority context before importing