### PR TITLE
Add homepage logo field to branding page and organize admin sidebar

### DIFF
--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -32,6 +32,13 @@
 				<li><a href="/admin/serials" onclick={() => mobileMenuOpen = false}>Serials Management</a></li>
 				<li><a href="/admin/holdings" onclick={() => mobileMenuOpen = false}>Holdings</a></li>
 				<li><a href="/admin/acquisitions" onclick={() => mobileMenuOpen = false}>Acquisitions</a></li>
+				<li><a href="/admin/ill" onclick={() => mobileMenuOpen = false}>Interlibrary Loan</a></li>
+				<li class="section-header">Configuration</li>
+				<li><a href="/admin/branding" onclick={() => mobileMenuOpen = false}>Branding & Appearance</a></li>
+				<li><a href="/admin/search-config" onclick={() => mobileMenuOpen = false}>Search Configuration</a></li>
+				<li><a href="/admin/display-config" onclick={() => mobileMenuOpen = false}>Display Configuration</a></li>
+				<li><a href="/admin/pages" onclick={() => mobileMenuOpen = false}>Content Pages</a></li>
+				<li class="section-header">View Site</li>
 				<li><a href="/catalog" onclick={() => mobileMenuOpen = false}>View Public Catalog</a></li>
 			</ul>
 			<div class="user-info">

--- a/src/routes/admin/branding/+page.server.ts
+++ b/src/routes/admin/branding/+page.server.ts
@@ -12,9 +12,10 @@ export const load: PageServerLoad = async ({ locals: { supabase } }) => {
 	if (error || !branding) {
 		return {
 			branding: {
-				library_name: 'Library Catalog',
-				library_tagline: null,
+				library_name: 'Chomp Chomp Library Catalog',
+				library_tagline: 'Search our collection',
 				logo_url: null,
+				homepage_logo_url: 'https://ik.imagekit.io/chompchomp/Chomp%20Chomp%20Library',
 				favicon_url: null,
 				primary_color: '#e73b42',
 				secondary_color: '#667eea',

--- a/src/routes/admin/branding/+page.svelte
+++ b/src/routes/admin/branding/+page.svelte
@@ -80,14 +80,25 @@
 					<h2>Logos & Icons</h2>
 
 					<div class="form-group">
-						<label for="logo_url">Logo URL</label>
+						<label for="logo_url">Navigation Logo URL (optional)</label>
 						<input
 							id="logo_url"
 							type="url"
 							bind:value={branding.logo_url}
 							placeholder="https://example.com/logo.png"
 						/>
-						<small>URL to your library's logo image</small>
+						<small>Logo for site navigation/header (not currently displayed)</small>
+					</div>
+
+					<div class="form-group">
+						<label for="homepage_logo_url">Homepage Hero Logo URL</label>
+						<input
+							id="homepage_logo_url"
+							type="url"
+							bind:value={branding.homepage_logo_url}
+							placeholder="https://example.com/homepage-logo.png"
+						/>
+						<small>Large logo displayed on homepage (currently shown)</small>
 					</div>
 
 					<div class="form-group">


### PR DESCRIPTION
Changes:
1. Added homepage_logo_url field to branding admin interface
2. Clearly labeled logo_url as "Navigation Logo" (not currently used)
3. Clearly labeled homepage_logo_url as "Homepage Hero Logo" (active)
4. Updated branding server defaults to include homepage_logo_url
5. Organized admin sidebar with new "Configuration" section
6. Added links to: Branding, Search Config, Display Config, Content Pages
7. Added ILL (Interlibrary Loan) link that was missing
8. Created "View Site" section for public catalog link

This makes all configuration pages discoverable from the admin sidebar.