### PR TITLE
Fix branding admin: Resolve Svelte 5 state mutation error

### DIFF
--- a/src/routes/admin/branding/+page.svelte
+++ b/src/routes/admin/branding/+page.svelte
@@ -416,7 +416,7 @@
 								<p class="empty-state">No header links yet. Add your first link below.</p>
 							{:else}
 								<div class="links-list">
-									{#each branding.header_links.sort((a, b) => a.order - b.order) as link, index}
+									{#each [...branding.header_links].sort((a, b) => a.order - b.order) as link, index}
 										<div class="link-item">
 											<span class="link-order">{link.order}</span>
 											<div class="link-details">
@@ -501,7 +501,7 @@
 								<p class="empty-state">No links yet. Add helpful links for your users.</p>
 							{:else}
 								<div class="links-list">
-									{#each branding.homepage_info_links.sort((a, b) => a.order - b.order) as link, index}
+									{#each [...branding.homepage_info_links].sort((a, b) => a.order - b.order) as link, index}
 										<div class="link-item">
 											<span class="link-order">{link.order}</span>
 											<div class="link-details">


### PR DESCRIPTION
- Fixed state_unsafe_mutation error in branding admin page
- Changed branding.header_links.sort() to [...branding.header_links].sort()
- Changed branding.homepage_info_links.sort() to [...branding.homepage_info_links].sort()
- In Svelte 5, cannot mutate state arrays directly with .sort()
- Must create a copy with spread operator before sorting

This fixes the error preventing branding settings from being saved.