### PR TITLE
Load branding with service role when available

### DIFF
--- a/src/lib/server/branding.ts
+++ b/src/lib/server/branding.ts
@@ -1,0 +1,45 @@
+import { env } from '$env/dynamic/private';
+import { PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { createClient, type SupabaseClient, type PostgrestError } from '@supabase/supabase-js';
+
+let serviceClient: SupabaseClient | null = null;
+
+function getBrandingClient(fallback: SupabaseClient) {
+	// Prefer the service role key when available so branding can be read without anon permissions
+	const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+
+	if (serviceRoleKey) {
+		if (!serviceClient) {
+			serviceClient = createClient(PUBLIC_SUPABASE_URL, serviceRoleKey, {
+				auth: {
+					autoRefreshToken: false,
+					persistSession: false
+				}
+			});
+		}
+		return serviceClient;
+	}
+
+	return fallback;
+}
+
+export async function loadActiveBranding(
+	supabase: SupabaseClient
+): Promise<{ branding: Record<string, any> | null; error: PostgrestError | null }> {
+	const client = getBrandingClient(supabase);
+
+	const { data, error } = await client
+		.from('branding_configuration')
+		.select('*')
+		.eq('is_active', true)
+		.single();
+
+	if (error) {
+		console.error('Error loading branding configuration:', error);
+	}
+
+	return {
+		branding: data || null,
+		error
+	};
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,3 +1,4 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals: { safeGetSession, supabase }, cookies, setHeaders }) => {
@@ -8,16 +9,7 @@ export const load: LayoutServerLoad = async ({ locals: { safeGetSession, supabas
     'cache-control': 'no-cache, no-store, must-revalidate'
   });
 
-  // Fetch active branding configuration with error handling
-  const { data: branding, error: brandingError } = await supabase
-    .from('branding_configuration')
-    .select('*')
-    .eq('is_active', true)
-    .single();
-
-  if (brandingError) {
-    console.error('Error loading branding configuration:', brandingError);
-  }
+  const { branding } = await loadActiveBranding(supabase);
 
   return {
     session,

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,3 +1,4 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession } }) => {
@@ -11,12 +12,8 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 		.eq('is_published', true)
 		.single();
 
-	// Fetch branding configuration for homepage
-	const { data: branding } = await supabase
-		.from('branding_configuration')
-		.select('homepage_logo_url, library_name, library_tagline, show_homepage_info, homepage_info_title, homepage_info_content, homepage_info_links')
-		.eq('is_active', true)
-		.single();
+	// Fetch branding configuration for homepage (use service key if available)
+	const { branding } = await loadActiveBranding(supabase);
 
 	return {
 		session,

--- a/src/routes/api/debug-branding/+server.ts
+++ b/src/routes/api/debug-branding/+server.ts
@@ -1,13 +1,9 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ locals: { supabase } }) => {
-  // Fetch branding configuration
-  const { data: branding, error } = await supabase
-    .from('branding_configuration')
-    .select('*')
-    .eq('is_active', true)
-    .single();
+  const { branding, error } = await loadActiveBranding(supabase);
 
   return json({
     success: !error,

--- a/src/routes/debug-branding/+page.server.ts
+++ b/src/routes/debug-branding/+page.server.ts
@@ -1,12 +1,8 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals: { supabase } }) => {
-  // Fetch branding configuration
-  const { data: branding, error } = await supabase
-    .from('branding_configuration')
-    .select('*')
-    .eq('is_active', true)
-    .single();
+  const { branding, error } = await loadActiveBranding(supabase);
 
   return {
     branding,


### PR DESCRIPTION
### Motivation
- The live site can fail to pick up admin-managed branding when anonymous DB access is restricted, causing header/footer to remain static or out-of-date.  
- Prefer reading the active `branding_configuration` using the Supabase service role when available so branding is reliably returned for layout and homepage rendering.  
- Centralize the branding lookup so multiple routes share the same logic and behavior.  

### Description
- Add a server-only helper `loadActiveBranding` in `src/lib/server/branding.ts` that uses `env.SUPABASE_SERVICE_ROLE_KEY` to create a service-role Supabase client and falls back to the provided client otherwise.  
- Update `src/routes/+layout.server.ts` to use `loadActiveBranding` for the root layout so header/footer decisions use the active branding.  
- Update `src/routes/+page.server.ts`, `src/routes/debug-branding/+page.server.ts`, and `src/routes/api/debug-branding/+server.ts` to reuse the same helper so homepage and debugging endpoints return the same active branding.  

### Testing
- Ran `npm run check` which invokes `svelte-kit sync` and `svelte-check` to validate the workspace.  
- The initial type error from importing a static private env value was fixed by switching to `env` from `$env/dynamic/private`.  
- `svelte-check` still reports pre-existing errors and warnings in unrelated files and the overall `npm run check` step fails due to those existing diagnostics.  
- No new runtime tests were added; manual debug endpoints and `debug-branding` page were updated to use the new loader for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc7b69b508330be5b5573131050cf)