### PR TITLE
Skip empty facet values and fall back to raw labels in facets

### DIFF
--- a/src/lib/utils/facets.ts
+++ b/src/lib/utils/facets.ts
@@ -282,11 +282,21 @@ function applyAggregation(value: any, config: FacetConfig): string | null {
  * Format facet values with labels and sorting
  */
 function formatFacetValues(counts: Map<string, number>, config: FacetConfig): Facet[] {
-	let facets: Facet[] = Array.from(counts.entries()).map(([value, count]) => ({
-		value,
-		label: formatValue(value, config),
-		count
-	}));
+	let facets: Facet[] = Array.from(counts.entries())
+		.map(([value, count]) => {
+			const stringValue = String(value ?? '').trim();
+			if (!stringValue) return null;
+
+			const formattedLabel = formatValue(stringValue, config);
+			const safeLabel = formattedLabel?.trim()?.length ? formattedLabel : stringValue;
+
+			return {
+				value: stringValue,
+				label: safeLabel,
+				count
+			};
+		})
+		.filter((facet): facet is Facet => facet !== null);
 
 	// Apply sorting
 	facets = sortFacets(facets, config);


### PR DESCRIPTION
### Motivation
- Facet lists in the sidebar were rendering empty rows when computed facet values were null/undefined or formatted to an empty string.
- The goal is to ensure the facets sidebar shows readable labels next to checkboxes and to avoid blank entries.

### Description
- Updated `formatFacetValues` in `src/lib/utils/facets.ts` to normalize values to trimmed strings and skip empty values. 
- If `formatValue` returns an empty string, the code now falls back to the raw trimmed value so a label is always shown. 
- The mapping step now filters out null results to keep the returned `Facet[]` type-safe. 

### Testing
- Ran `npm run check` to surface Svelte/TypeScript diagnostics. 
- `svelte-check` reported existing diagnostics across the project (125 errors and 195 warnings) which appear unrelated to the facet formatting change. 
- No additional automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ccb26fd008330aed8473d37d2b1b3)