### PR TITLE
Temporarily hide footer sitewide while branding is fixed

### DIFF
--- a/src/lib/server/branding.ts
+++ b/src/lib/server/branding.ts
@@ -1,0 +1,47 @@
+import { env } from '$env/dynamic/private';
+import { PUBLIC_SUPABASE_URL } from '$env/static/public';
+import { createClient, type SupabaseClient, type PostgrestError } from '@supabase/supabase-js';
+
+let serviceClient: SupabaseClient | null = null;
+
+function getBrandingClient(fallback: SupabaseClient) {
+	// Prefer the service role key when available so branding can be read without anon permissions
+	const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+
+	if (serviceRoleKey) {
+		if (!serviceClient) {
+			serviceClient = createClient(PUBLIC_SUPABASE_URL, serviceRoleKey, {
+				auth: {
+					autoRefreshToken: false,
+					persistSession: false
+				}
+			});
+		}
+		return serviceClient;
+	}
+
+	return fallback;
+}
+
+export async function loadActiveBranding(
+	supabase: SupabaseClient
+): Promise<{ branding: Record<string, any> | null; error: PostgrestError | null }> {
+	const client = getBrandingClient(supabase);
+
+	const { data, error } = await client
+		.from('branding_configuration')
+		.select('*')
+		.eq('is_active', true)
+		.order('updated_at', { ascending: false })
+		.limit(1)
+		.maybeSingle();
+
+	if (error) {
+		console.error('Error loading branding configuration:', error);
+	}
+
+	return {
+		branding: data || null,
+		error
+	};
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,3 +1,4 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals: { safeGetSession, supabase }, cookies, setHeaders }) => {
@@ -8,16 +9,7 @@ export const load: LayoutServerLoad = async ({ locals: { safeGetSession, supabas
     'cache-control': 'no-cache, no-store, must-revalidate'
   });
 
-  // Fetch active branding configuration with error handling
-  const { data: branding, error: brandingError } = await supabase
-    .from('branding_configuration')
-    .select('*')
-    .eq('is_active', true)
-    .single();
-
-  if (brandingError) {
-    console.error('Error loading branding configuration:', brandingError);
-  }
+  const { branding } = await loadActiveBranding(supabase);
 
   return {
     session,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -69,18 +69,8 @@
 	// Show custom header on all non-admin pages if enabled
 	let showCustomHeader = $derived(branding.show_header === true && !$page.url.pathname.startsWith('/admin'));
 
-	// Show footer on non-admin pages if there's any footer content
-	let showFooter = $derived(
-		!$page.url.pathname.startsWith('/admin') &&
-		(branding.show_powered_by === true ||
-		 branding.footer_text ||
-		 branding.contact_email ||
-		 branding.contact_phone ||
-		 branding.contact_address ||
-		 branding.facebook_url ||
-		 branding.twitter_url ||
-		 branding.instagram_url)
-	);
+// Temporarily hide footer on all pages (branding footer rendering is paused)
+let showFooter = $derived(false);
 
 	onMount(() => {
 		const { data: authData } = data.supabase.auth.onAuthStateChange(() => {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,3 +1,4 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession } }) => {
@@ -11,12 +12,8 @@ export const load: PageServerLoad = async ({ locals: { supabase, safeGetSession 
 		.eq('is_published', true)
 		.single();
 
-	// Fetch branding configuration for homepage
-	const { data: branding } = await supabase
-		.from('branding_configuration')
-		.select('homepage_logo_url, library_name, library_tagline, show_homepage_info, homepage_info_title, homepage_info_content, homepage_info_links')
-		.eq('is_active', true)
-		.single();
+	// Fetch branding configuration for homepage (use service key if available)
+	const { branding } = await loadActiveBranding(supabase);
 
 	return {
 		session,

--- a/src/routes/admin/branding/+page.server.ts
+++ b/src/routes/admin/branding/+page.server.ts
@@ -1,12 +1,8 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals: { supabase } }) => {
-	// Fetch the active branding configuration
-	const { data: branding, error } = await supabase
-		.from('branding_configuration')
-		.select('*')
-		.eq('is_active', true)
-		.single();
+	const { branding, error } = await loadActiveBranding(supabase);
 
 	// If no branding exists, return defaults
 	if (error || !branding) {

--- a/src/routes/api/debug-branding/+server.ts
+++ b/src/routes/api/debug-branding/+server.ts
@@ -1,13 +1,9 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ locals: { supabase } }) => {
-  // Fetch branding configuration
-  const { data: branding, error } = await supabase
-    .from('branding_configuration')
-    .select('*')
-    .eq('is_active', true)
-    .single();
+  const { branding, error } = await loadActiveBranding(supabase);
 
   return json({
     success: !error,

--- a/src/routes/debug-branding/+page.server.ts
+++ b/src/routes/debug-branding/+page.server.ts
@@ -1,12 +1,8 @@
+import { loadActiveBranding } from '$lib/server/branding';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals: { supabase } }) => {
-  // Fetch branding configuration
-  const { data: branding, error } = await supabase
-    .from('branding_configuration')
-    .select('*')
-    .eq('is_active', true)
-    .single();
+  const { branding, error } = await loadActiveBranding(supabase);
 
   return {
     branding,


### PR DESCRIPTION
### Motivation
- Prevent display of stale or incorrect branding in the site footer while branding retrieval and fixes are in progress.
- Provide a fast, low-risk rollback that removes visible branding until service-role-aware branding reads are verified.
- Centralize branding retrieval so routes can be updated to use a service-role-aware client before re-enabling the footer.

### Description
- Add `src/lib/server/branding.ts` with `getBrandingClient` that prefers `env.SUPABASE_SERVICE_ROLE_KEY` and `loadActiveBranding` that orders by `updated_at`, limits to 1, and uses `.maybeSingle()` to tolerate multiple active rows.
- Replace inline branding queries with `loadActiveBranding` in `src/routes/+layout.server.ts`, `src/routes/+page.server.ts`, `src/routes/admin/branding/+page.server.ts`, `src/routes/api/debug-branding/+server.ts`, and `src/routes/debug-branding/+page.server.ts` so all routes use the same logic.
- Temporarily disable footer rendering by changing `showFooter` in `src/routes/+layout.svelte` to `let showFooter = $derived(false);` so the footer is hidden sitewide.
- Leave debug logging in `+layout.svelte` to assist verification while fixes are applied.

### Testing
- Ran `npm run check` (which runs `svelte-kit sync` and `svelte-check`) to validate the workspace.
- The `npm run check` run failed due to pre-existing `svelte-check` diagnostics in unrelated files, and no new `svelte-check` errors were introduced by these changes.
- No automated runtime tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc7b69b508330be5b5573131050cf)