### PR TITLE
Temporarily disable facets UI and add safe fallback for empty facet labels

### DIFF
--- a/src/lib/utils/facets.ts
+++ b/src/lib/utils/facets.ts
@@ -282,11 +282,22 @@ function applyAggregation(value: any, config: FacetConfig): string | null {
  * Format facet values with labels and sorting
  */
 function formatFacetValues(counts: Map<string, number>, config: FacetConfig): Facet[] {
-	let facets: Facet[] = Array.from(counts.entries()).map(([value, count]) => ({
-		value,
-		label: formatValue(value, config),
-		count
-	}));
+	let facets: Facet[] = Array.from(counts.entries())
+		.map(([value, count]) => {
+			const stringValue = String(value ?? '').trim();
+
+			const formattedLabel = formatValue(stringValue, config);
+			const safeLabel = formattedLabel?.trim()?.length
+				? formattedLabel
+				: stringValue || 'Unknown';
+
+			return {
+				value: stringValue || 'Unknown',
+				label: safeLabel,
+				count
+			};
+		})
+		.filter((facet): facet is Facet => facet !== null);
 
 	// Apply sorting
 	facets = sortFacets(facets, config);

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -26,6 +26,8 @@
 	let selectedRecords = $state<string[]>([]);
 	let emailingRecords = $state(false);
 	let showCovers = $state(true);
+	// Temporary kill-switch to hide facets until the blank-label issue is resolved in production
+	const facetsEnabled = false;
 	let exportFields = $state({
 		title: true,
 		author: true,
@@ -449,23 +451,25 @@
 	<header class="search-header" role="banner">
 		<div class="header-top">
 			<h1 id="results-heading">Search Results</h1>
-			<button
-				class="mobile-filter-toggle"
-				onclick={toggleMobileFilters}
-				aria-label="Toggle filters"
-				aria-expanded={mobileFiltersOpen}
-				aria-controls="filter-sidebar"
-			>
-				<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-					<path
-						d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z"
-					/>
-				</svg>
-				Filters
-				{#if hasActiveFilters}
-					<span class="filter-badge" aria-label="{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)} active filters">{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)}</span>
-				{/if}
-			</button>
+			{#if facetsEnabled}
+				<button
+					class="mobile-filter-toggle"
+					onclick={toggleMobileFilters}
+					aria-label="Toggle filters"
+					aria-expanded={mobileFiltersOpen}
+					aria-controls="filter-sidebar"
+				>
+					<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+						<path
+							d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z"
+						/>
+					</svg>
+					Filters
+					{#if hasActiveFilters}
+						<span class="filter-badge" aria-label="{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)} active filters">{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)}</span>
+					{/if}
+				</button>
+			{/if}
 		</div>
 
 		<div class="query-display">
@@ -645,19 +649,21 @@
 
 	<!-- Main Content Area -->
 	<div class="content-wrapper">
-		<!-- Sidebar with Facets -->
-		<aside class="sidebar" class:mobile-open={mobileFiltersOpen}>
-			<div class="sidebar-header">
-				<h2>Refine Results</h2>
-				<button class="mobile-close" onclick={toggleMobileFilters}>×</button>
-			</div>
-			<FacetSidebar
-				facets={data.facets}
-				facetConfigs={data.facetConfigs}
-				currentFilters={data.query}
-				onFilterChange={updateUrl}
-			/>
-		</aside>
+		<!-- Sidebar with Facets (temporarily disabled) -->
+		{#if facetsEnabled}
+			<aside class="sidebar" class:mobile-open={mobileFiltersOpen}>
+				<div class="sidebar-header">
+					<h2>Refine Results</h2>
+					<button class="mobile-close" onclick={toggleMobileFilters}>×</button>
+				</div>
+				<FacetSidebar
+					facets={data.facets}
+					facetConfigs={data.facetConfigs}
+					currentFilters={data.query}
+					onFilterChange={updateUrl}
+				/>
+			</aside>
+		{/if}
 
 		<!-- Results Area -->
 		<main class="results-area">
@@ -914,7 +920,7 @@
 </div>
 
 <!-- Mobile filter overlay -->
-{#if mobileFiltersOpen}
+{#if facetsEnabled && mobileFiltersOpen}
 	<div class="mobile-overlay" onclick={toggleMobileFilters}></div>
 {/if}
 

--- a/src/routes/catalog/search/results/FacetSidebar.svelte
+++ b/src/routes/catalog/search/results/FacetSidebar.svelte
@@ -68,12 +68,13 @@
 						{#if config.display_type === 'checkbox_list'}
 							{#each facetValues as facet}
 								<label class="facet-item">
+									{@const displayLabel = facet.label?.trim() || facet.value?.trim() || 'Unknown'}
 									<input
 										type="checkbox"
 										checked={isSelected(config.filter_param_name, facet.value)}
 										onchange={() => toggleFacet(config.filter_param_name, facet.value)}
 									/>
-									<span class="facet-label">{facet.label}</span>
+									<span class="facet-label">{displayLabel}</span>
 									{#if config.show_count}
 										<span class="facet-count">{facet.count.toLocaleString()}</span>
 									{/if}
@@ -82,6 +83,7 @@
 						{:else if config.display_type === 'date_range'}
 							<!-- Date range slider or buttons -->
 							{#each facetValues as facet}
+								{@const displayLabel = facet.label?.trim() || facet.value?.trim() || 'Unknown'}
 								<button
 									class="facet-year-button"
 									onclick={() => {
@@ -99,7 +101,7 @@
 										}
 									}}
 								>
-									<span class="facet-label">{facet.label}</span>
+									<span class="facet-label">{displayLabel}</span>
 									{#if config.show_count}
 										<span class="facet-count">{facet.count.toLocaleString()}</span>
 									{/if}
@@ -109,12 +111,13 @@
 							<!-- Tag cloud view -->
 							<div class="tag-cloud">
 								{#each facetValues as facet}
+									{@const displayLabel = facet.label?.trim() || facet.value?.trim() || 'Unknown'}
 									<button
 										class="tag-item"
 										class:selected={isSelected(config.filter_param_name, facet.value)}
 										onclick={() => toggleFacet(config.filter_param_name, facet.value)}
 									>
-										{facet.label}
+										{displayLabel}
 										{#if config.show_count}
 											<span class="tag-count">({facet.count})</span>
 										{/if}


### PR DESCRIPTION
### Motivation
- Facet rendering produced blank or empty labels when raw facet values or formatted labels were null, undefined, or trimmed to empty strings. 
- A robust fallback label (`'Unknown'`) was needed so UI components can rely on non-empty identifiers when rendering facets. 
- While the label issue is being investigated in production, the facets sidebar should be hidden to avoid showing broken/empty UI. 

### Description
- Updated `formatFacetValues` in `src/lib/utils/facets.ts` to coerce raw facet values to trimmed strings, compute a `safeLabel` that falls back to the raw value or `'Unknown'`, and return a non-empty `value`. 
- Updated `src/routes/catalog/search/results/FacetSidebar.svelte` to compute a `displayLabel` as ``facet.label?.trim() || facet.value?.trim() || 'Unknown'`` and use it for checkbox lists, date buttons, and tag-cloud items. 
- Added a temporary kill-switch `const facetsEnabled = false` to `src/routes/catalog/search/results/+page.svelte` and wrapped the mobile filters toggle, the `FacetSidebar` rendering, and the mobile overlay in `{#if facetsEnabled}` conditionals to fully hide the facets UI. 
- Preserved existing sorting, max-items, and zero-count filtering behavior in the facet formatting logic. 

### Testing
- Ran `npm run check` (which invokes `svelte-check`) after the facet formatting changes and confirmed no new facet-related TypeScript/Svelte diagnostics were introduced. 
- `svelte-check` still reports preexisting unrelated diagnostics elsewhere in the codebase and those were not changed by this PR. 
- No automated unit tests were added or modified for these changes. 
- No additional automated checks were executed after adding the temporary kill-switch to hide facets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ccb26fd008330aed8473d37d2b1b3)