### PR TITLE
Temporarily disable facets and footer

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -69,8 +69,14 @@
 	// Show custom header on all non-admin pages if enabled
 	let showCustomHeader = $derived(branding.show_header === true && !$page.url.pathname.startsWith('/admin'));
 
-// Temporarily hide footer on all pages (branding footer rendering is paused)
-let showFooter = $derived(false);
+	// Temporary kill-switch while the admin branding toggle is unreliable
+	const FOOTER_TEMPORARILY_DISABLED = true;
+	let showFooter = $derived(
+		branding.show_powered_by === true &&
+			!!branding.footer_text &&
+			!$page.url.pathname.startsWith('/admin') &&
+			!FOOTER_TEMPORARILY_DISABLED
+	);
 
 	onMount(() => {
 		const { data: authData } = data.supabase.auth.onAuthStateChange(() => {

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -26,8 +26,11 @@
 	let selectedRecords = $state<string[]>([]);
 	let emailingRecords = $state(false);
 	let showCovers = $state(true);
-	// Temporary kill-switch to hide facets until the blank-label issue is resolved in production
-	const facetsEnabled = false;
+	// Temporary kill-switch while the admin branding toggle is unreliable
+	const FACETS_TEMPORARILY_DISABLED = true;
+	const facetsEnabled = $derived(
+		(($page.data as any)?.branding?.show_facets ?? true) && !FACETS_TEMPORARILY_DISABLED
+	);
 	let exportFields = $state({
 		title: true,
 		author: true,


### PR DESCRIPTION
### Motivation
- Admin branding toggles for facets and footer are currently unreliable, so the UI needs a temporary way to keep those features off until the admin controls are fixed.
- Keep the changes minimal and reversible so the features can be restored quickly once the underlying issue is resolved.

### Description
- Added a temporary footer kill-switch by introducing `FOOTER_TEMPORARILY_DISABLED` and computing `showFooter` in `src/routes/+layout.svelte` to require `branding.show_powered_by`, `branding.footer_text`, non-admin paths, and the temporary flag.
- Gate facet rendering in `src/routes/catalog/search/results/+page.svelte` behind the branding flag and a temporary `FACETS_TEMPORARILY_DISABLED` by computing `facetsEnabled` from `($page.data as any)?.branding?.show_facets` and the temporary flag.
- Added short explanatory comments near the new flags and replaced the previous hard-coded disables with the new derived values.
- Changes were committed with message `Temporarily disable facets and footer`.

### Testing
- No automated tests were executed as part of this change.
- Patches applied successfully and files modified were `src/routes/+layout.svelte` and `src/routes/catalog/search/results/+page.svelte`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d034a7dbc83309efed84d9248559a)