### PR TITLE
Harden facet labels to always render

### DIFF
--- a/src/lib/utils/facets.ts
+++ b/src/lib/utils/facets.ts
@@ -282,11 +282,21 @@ function applyAggregation(value: any, config: FacetConfig): string | null {
  * Format facet values with labels and sorting
  */
 function formatFacetValues(counts: Map<string, number>, config: FacetConfig): Facet[] {
-	let facets: Facet[] = Array.from(counts.entries()).map(([value, count]) => ({
-		value,
-		label: formatValue(value, config),
-		count
-	}));
+	let facets: Facet[] = Array.from(counts.entries())
+		.map(([value, count]) => {
+			const stringValue = String(value ?? '').trim();
+			if (!stringValue) return null;
+
+			const formattedLabel = formatValue(stringValue, config);
+			const safeLabel = formattedLabel?.trim()?.length ? formattedLabel : stringValue;
+
+			return {
+				value: stringValue,
+				label: safeLabel || 'Unknown',
+				count
+			};
+		})
+		.filter((facet): facet is Facet => facet !== null);
 
 	// Apply sorting
 	facets = sortFacets(facets, config);

--- a/src/routes/catalog/search/results/FacetSidebar.svelte
+++ b/src/routes/catalog/search/results/FacetSidebar.svelte
@@ -67,13 +67,19 @@
 					<div class="facet-list">
 						{#if config.display_type === 'checkbox_list'}
 							{#each facetValues as facet}
+								{@const displayLabel = (() => {
+									const raw = facet.label ?? facet.value ?? 'Unknown';
+									const text = String(raw).trim();
+									return text || 'Unknown';
+								})()}
 								<label class="facet-item">
 									<input
 										type="checkbox"
 										checked={isSelected(config.filter_param_name, facet.value)}
-										onchange={() => toggleFacet(config.filter_param_name, facet.value)}
+										onchange={() => toggleFacet(config.filter_param_name, facet.value ?? displayLabel)}
+										aria-label={displayLabel}
 									/>
-									<span class="facet-label">{facet.label}</span>
+									<span class="facet-label">{displayLabel}</span>
 									{#if config.show_count}
 										<span class="facet-count">{facet.count.toLocaleString()}</span>
 									{/if}
@@ -82,6 +88,11 @@
 						{:else if config.display_type === 'date_range'}
 							<!-- Date range slider or buttons -->
 							{#each facetValues as facet}
+								{@const displayLabel = (() => {
+									const raw = facet.label ?? facet.value ?? 'Unknown';
+									const text = String(raw).trim();
+									return text || 'Unknown';
+								})()}
 								<button
 									class="facet-year-button"
 									onclick={() => {
@@ -99,7 +110,7 @@
 										}
 									}}
 								>
-									<span class="facet-label">{facet.label}</span>
+									<span class="facet-label">{displayLabel}</span>
 									{#if config.show_count}
 										<span class="facet-count">{facet.count.toLocaleString()}</span>
 									{/if}
@@ -109,12 +120,17 @@
 							<!-- Tag cloud view -->
 							<div class="tag-cloud">
 								{#each facetValues as facet}
+									{@const displayLabel = (() => {
+										const raw = facet.label ?? facet.value ?? 'Unknown';
+										const text = String(raw).trim();
+										return text || 'Unknown';
+									})()}
 									<button
 										class="tag-item"
 										class:selected={isSelected(config.filter_param_name, facet.value)}
-										onclick={() => toggleFacet(config.filter_param_name, facet.value)}
+										onclick={() => toggleFacet(config.filter_param_name, facet.value ?? displayLabel)}
 									>
-										{facet.label}
+										{displayLabel}
 										{#if config.show_count}
 											<span class="tag-count">({facet.count})</span>
 										{/if}


### PR DESCRIPTION
### Motivation
- Facet items could render blank or whitespace-only labels when raw values or formatted labels were null, undefined, or non-string, breaking the UI.
- The facets UI needs safe, deterministic labels so filter controls and accessibility attributes never show empty text.
- Defensive normalization avoids runtime errors when downstream code expects string labels.

### Description
- Normalize and filter facet entries in `src/lib/utils/facets.ts` by coercing values to trimmed strings, skipping empty keys, and using the formatted label or the raw string value with a fallback of `'Unknown'`.
- Compute a safe `displayLabel` in `src/routes/catalog/search/results/FacetSidebar.svelte` by coercing and trimming `facet.label`/`facet.value` and falling back to `'Unknown'` when needed.
- Use `displayLabel` for visible text and `aria-label`, and pass `facet.value ?? displayLabel` into `toggleFacet` to keep filter wiring working when `facet.value` is missing.
- Preserve existing sorting, `max_items`, and zero-count filtering behavior in the facet formatting pipeline.

### Testing
- No automated unit tests were added or run for these edits.
- `svelte-check` was not re-run and preexisting diagnostics remain in the codebase.
- No additional automated checks or CI jobs were executed after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ccb26fd008330aed8473d37d2b1b3)