### PR TITLE
Fix FacetSidebar build error by centralizing facet label helper

### DIFF
--- a/src/lib/utils/facets.ts
+++ b/src/lib/utils/facets.ts
@@ -282,11 +282,21 @@ function applyAggregation(value: any, config: FacetConfig): string | null {
  * Format facet values with labels and sorting
  */
 function formatFacetValues(counts: Map<string, number>, config: FacetConfig): Facet[] {
-	let facets: Facet[] = Array.from(counts.entries()).map(([value, count]) => ({
-		value,
-		label: formatValue(value, config),
-		count
-	}));
+	let facets: Facet[] = Array.from(counts.entries())
+		.map(([value, count]) => {
+			const stringValue = String(value ?? '').trim();
+			if (!stringValue) return null;
+
+			const formattedLabel = formatValue(stringValue, config);
+			const safeLabel = formattedLabel?.trim()?.length ? formattedLabel : stringValue;
+
+			return {
+				value: stringValue,
+				label: safeLabel || 'Unknown',
+				count
+			};
+		})
+		.filter((facet): facet is Facet => facet !== null);
 
 	// Apply sorting
 	facets = sortFacets(facets, config);

--- a/src/routes/catalog/search/results/+page.svelte
+++ b/src/routes/catalog/search/results/+page.svelte
@@ -26,6 +26,7 @@
 	let selectedRecords = $state<string[]>([]);
 	let emailingRecords = $state(false);
 	let showCovers = $state(true);
+	let showFacets = $derived((data as any)?.branding?.show_facets !== false);
 	let exportFields = $state({
 		title: true,
 		author: true,
@@ -449,23 +450,25 @@
 	<header class="search-header" role="banner">
 		<div class="header-top">
 			<h1 id="results-heading">Search Results</h1>
-			<button
-				class="mobile-filter-toggle"
-				onclick={toggleMobileFilters}
-				aria-label="Toggle filters"
-				aria-expanded={mobileFiltersOpen}
-				aria-controls="filter-sidebar"
-			>
-				<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-					<path
-						d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z"
-					/>
-				</svg>
-				Filters
-				{#if hasActiveFilters}
-					<span class="filter-badge" aria-label="{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)} active filters">{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)}</span>
-				{/if}
-			</button>
+			{#if showFacets}
+				<button
+					class="mobile-filter-toggle"
+					onclick={toggleMobileFilters}
+					aria-label="Toggle filters"
+					aria-expanded={mobileFiltersOpen}
+					aria-controls="filter-sidebar"
+				>
+					<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+						<path
+							d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z"
+						/>
+					</svg>
+					Filters
+					{#if hasActiveFilters}
+						<span class="filter-badge" aria-label="{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)} active filters">{(data.query.material_types?.length || 0) + (data.query.languages?.length || 0) + (data.query.availability?.length || 0) + (data.query.locations?.length || 0)}</span>
+					{/if}
+				</button>
+			{/if}
 		</div>
 
 		<div class="query-display">
@@ -646,18 +649,20 @@
 	<!-- Main Content Area -->
 	<div class="content-wrapper">
 		<!-- Sidebar with Facets -->
-		<aside class="sidebar" class:mobile-open={mobileFiltersOpen}>
-			<div class="sidebar-header">
-				<h2>Refine Results</h2>
-				<button class="mobile-close" onclick={toggleMobileFilters}>×</button>
-			</div>
-			<FacetSidebar
-				facets={data.facets}
-				facetConfigs={data.facetConfigs}
-				currentFilters={data.query}
-				onFilterChange={updateUrl}
-			/>
-		</aside>
+		{#if showFacets}
+			<aside class="sidebar" class:mobile-open={mobileFiltersOpen}>
+				<div class="sidebar-header">
+					<h2>Refine Results</h2>
+					<button class="mobile-close" onclick={toggleMobileFilters}>×</button>
+				</div>
+				<FacetSidebar
+					facets={data.facets}
+					facetConfigs={data.facetConfigs}
+					currentFilters={data.query}
+					onFilterChange={updateUrl}
+				/>
+			</aside>
+		{/if}
 
 		<!-- Results Area -->
 		<main class="results-area">
@@ -914,7 +919,7 @@
 </div>
 
 <!-- Mobile filter overlay -->
-{#if mobileFiltersOpen}
+{#if showFacets && mobileFiltersOpen}
 	<div class="mobile-overlay" onclick={toggleMobileFilters}></div>
 {/if}
 

--- a/src/routes/catalog/search/results/FacetSidebar.svelte
+++ b/src/routes/catalog/search/results/FacetSidebar.svelte
@@ -51,6 +51,12 @@
 		}
 		return values;
 	}
+
+	function getFacetLabel(facet: Facet) {
+		const raw = facet?.label ?? facet?.value ?? 'Unknown';
+		const text = String(raw ?? '').trim();
+		return text || 'Unknown';
+	}
 </script>
 
 <div class="facet-sidebar">
@@ -71,9 +77,11 @@
 									<input
 										type="checkbox"
 										checked={isSelected(config.filter_param_name, facet.value)}
-										onchange={() => toggleFacet(config.filter_param_name, facet.value)}
+										onchange={() =>
+											toggleFacet(config.filter_param_name, facet.value ?? getFacetLabel(facet))}
+										aria-label={getFacetLabel(facet)}
 									/>
-									<span class="facet-label">{facet.label}</span>
+									<span class="facet-label">{getFacetLabel(facet)}</span>
 									{#if config.show_count}
 										<span class="facet-count">{facet.count.toLocaleString()}</span>
 									{/if}
@@ -99,7 +107,7 @@
 										}
 									}}
 								>
-									<span class="facet-label">{facet.label}</span>
+									<span class="facet-label">{getFacetLabel(facet)}</span>
 									{#if config.show_count}
 										<span class="facet-count">{facet.count.toLocaleString()}</span>
 									{/if}
@@ -112,9 +120,10 @@
 									<button
 										class="tag-item"
 										class:selected={isSelected(config.filter_param_name, facet.value)}
-										onclick={() => toggleFacet(config.filter_param_name, facet.value)}
+										onclick={() =>
+											toggleFacet(config.filter_param_name, facet.value ?? getFacetLabel(facet))}
 									>
-										{facet.label}
+										{getFacetLabel(facet)}
 										{#if config.show_count}
 											<span class="tag-count">({facet.count})</span>
 										{/if}


### PR DESCRIPTION
### Motivation
- Resolve a Svelte build error caused by inline `@const` label expressions in the facet sidebar template.
- Ensure facet labels are consistently normalized and safe for display and accessibility when `facet.label` or `facet.value` are missing or non-string.
- Preserve filter behavior when `facet.value` is absent by using a deterministic safe label fallback.

### Description
- Add a shared `getFacetLabel(facet)` helper in `src/routes/catalog/search/results/FacetSidebar.svelte` and replace multiple inline label expressions with calls to this helper. 
- Use the safe label for visible text, `aria-label`, and as a fallback argument to `toggleFacet` (i.e. `facet.value ?? getFacetLabel(facet)`).
- Previously introduced changes included deriving `showFacets` from branding in `src/routes/catalog/search/results/+page.svelte` and conditionally rendering the mobile filter toggle, sidebar, and mobile overlay, and hardening formatting in `src/lib/utils/facets.ts` to coerce values to trimmed strings, filter empty keys, and fall back to a safe label.

### Testing
- No automated unit tests were added or executed for these changes.
- No CI or `npm run build` was executed as part of this PR; the change is focused on resolving the prior template compile error.
- Local edits were committed after applying the fix, but no automated verification completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ccb26fd008330aed8473d37d2b1b3)