### PR TITLE
Fix search to handle special characters

### DIFF
--- a/DIACRITIC_SEARCH_FIX.md
+++ b/DIACRITIC_SEARCH_FIX.md
@@ -1,0 +1,138 @@
+# Fix: Special Character Search Issue
+
+**Problem:** Searching for "Zizek" doesn't return results for "Žižek"
+
+**Solution:** Apply database migration to enable diacritic-insensitive search
+
+---
+
+## Quick Start (3 Steps)
+
+### Step 1: Run Diagnostic Test
+
+1. Open **Supabase Dashboard** → **SQL Editor**
+2. Click **New Query**
+3. Copy and paste the contents of: `test-diacritic-search.sql`
+4. Click **Run**
+5. Review the test results
+
+### Step 2: Apply Migration (if needed)
+
+**If tests show the migration is NOT applied:**
+
+1. In **Supabase SQL Editor**, click **New Query**
+2. Copy and paste the contents of: `migrations/024_diacritic_insensitive_search.sql`
+3. Click **Run**
+4. Wait for "Success" message
+
+**If tests show the migration IS applied but search still doesn't work:**
+
+Run this to rebuild search vectors:
+
+```sql
+UPDATE marc_records SET updated_at = NOW();
+```
+
+### Step 3: Test the Fix
+
+1. Go to your catalog search page
+2. Search for "Zizek" (without special characters)
+3. You should now see results for "Žižek"
+
+---
+
+## Files Created
+
+1. **test-diacritic-search.sql** - Diagnostic tests (run this first!)
+2. **MIGRATION_024_REFERENCE.md** - Complete documentation with examples
+3. **DIACRITIC_SEARCH_FIX.md** - This quick start guide
+
+---
+
+## How It Works
+
+The fix works by normalizing text on both sides:
+
+**Database side (indexing):**
+- When a record is saved with "Žižek"
+- It's indexed as "Zizek" (diacritics removed)
+
+**Application side (searching):**
+- When user searches "Zizek"
+- It's normalized to "Zizek" (already no diacritics)
+- Matches the indexed "Zizek"
+- Returns records with original "Žižek"
+
+**Result:** User can type "Zizek" and find "Žižek" ✅
+
+---
+
+## Characters Supported
+
+Works with all common diacritics:
+
+- À Á Â Ã Ä Å → A
+- È É Ê Ë → E
+- Ì Í Î Ï → I
+- Ò Ó Ô Õ Ö → O
+- Ù Ú Û Ü → U
+- Ñ → N
+- Ç → C
+- Ž → Z
+- Š → S
+- And many more...
+
+---
+
+## What If It Still Doesn't Work?
+
+### Option A: Check the diagnostic results
+
+Look at the test output:
+- ❌ FAIL results indicate which part needs fixing
+- ✅ PASS results confirm that part is working
+
+### Option B: Common issues
+
+**Issue 1: No records with diacritics exist**
+- Solution: The search works, you just don't have test data
+- Try creating a test record (see MIGRATION_024_REFERENCE.md)
+
+**Issue 2: Search vectors not rebuilt**
+- Solution: Run `UPDATE marc_records SET updated_at = NOW();`
+
+**Issue 3: unaccent extension not available**
+- Solution: Contact Supabase support or check PostgreSQL version
+
+**Issue 4: Client-side code not deployed**
+- Solution: Clear browser cache and refresh
+- Check that `/src/lib/utils/text-normalize.ts` exists
+
+---
+
+## Need More Help?
+
+See **MIGRATION_024_REFERENCE.md** for:
+- Detailed explanation of how it works
+- Troubleshooting guide
+- Example SQL queries
+- Rollback instructions
+- Performance impact analysis
+
+---
+
+## Summary
+
+✅ **Files ready to use:**
+- Diagnostic test script
+- Migration SQL (if needed)
+- Complete documentation
+
+✅ **Next action:**
+1. Run `test-diacritic-search.sql` in Supabase SQL Editor
+2. Follow the results to determine if migration needs to be applied
+3. Test by searching for "Zizek" in your catalog
+
+---
+
+That's it! Once the migration is applied and search vectors are rebuilt, searching for "Zizek" will find "Žižek" automatically.

--- a/MIGRATION_024_REFERENCE.md
+++ b/MIGRATION_024_REFERENCE.md
@@ -1,0 +1,362 @@
+# Migration 024: Diacritic-Insensitive Search
+
+**Purpose:** Enable searching for "Zizek" to match "Žižek", "Cafe" to match "Café", etc.
+
+**Created:** 2026-01-04
+**Status:** Ready to apply
+**Dependencies:** PostgreSQL with unaccent extension support
+
+---
+
+## What This Migration Does
+
+1. **Enables the `unaccent` extension** - PostgreSQL extension that removes diacritics
+2. **Creates `remove_diacritics()` function** - Wrapper function for safe diacritic removal
+3. **Updates search vector trigger** - Modifies `update_marc_search_vector()` to normalize text before indexing
+4. **Rebuilds search vectors** - Updates all existing records with normalized search data
+5. **Creates helper function** - Adds `normalize_search_query()` for application use
+
+---
+
+## How to Apply This Migration
+
+### Option 1: Via Supabase Dashboard (Recommended)
+
+1. Open your Supabase project dashboard
+2. Navigate to **SQL Editor** (left sidebar)
+3. Click **New Query**
+4. Copy and paste the SQL below
+5. Click **Run** or press `Ctrl+Enter`
+6. Wait for confirmation message
+
+### Option 2: Via Supabase CLI
+
+```bash
+supabase db push migrations/024_diacritic_insensitive_search.sql
+```
+
+---
+
+## Migration SQL
+
+```sql
+-- Migration: Add diacritic-insensitive search
+-- Allows searching for "Zizek" to match "Žižek", etc.
+-- Created: 2026-01-04
+
+-- First, try to enable the unaccent extension
+-- This extension removes diacritics from text
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Create a wrapper function that uses unaccent if available
+-- This function is IMMUTABLE which is required for use in indexes
+CREATE OR REPLACE FUNCTION remove_diacritics(text)
+RETURNS text AS $$
+BEGIN
+  -- Try to use unaccent if available
+  BEGIN
+    RETURN unaccent($1);
+  EXCEPTION WHEN undefined_function THEN
+    -- If unaccent is not available, return original text
+    -- At least searches will still work, just not diacritic-insensitive
+    RETURN $1;
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Update the search_vector function to remove diacritics before indexing
+CREATE OR REPLACE FUNCTION update_marc_search_vector()
+RETURNS TRIGGER AS $$
+DECLARE
+  subject_text TEXT := '';
+BEGIN
+  -- Extract all subject headings from the subject_topical array
+  IF NEW.subject_topical IS NOT NULL THEN
+    SELECT string_agg(elem->>'a', ' ')
+    INTO subject_text
+    FROM unnest(NEW.subject_topical) AS elem
+    WHERE elem->>'a' IS NOT NULL;
+  END IF;
+
+  -- Apply remove_diacritics() to all text before creating search_vector
+  NEW.search_vector :=
+    -- 'A' weight (highest): Title
+    setweight(
+      to_tsvector('english', remove_diacritics(COALESCE(NEW.title_statement->>'a', ''))),
+      'A'
+    ) ||
+
+    -- 'B' weight (high): Author and Subjects
+    setweight(
+      to_tsvector('english', remove_diacritics(COALESCE(NEW.main_entry_personal_name->>'a', ''))),
+      'B'
+    ) ||
+    setweight(
+      to_tsvector('english', remove_diacritics(COALESCE(subject_text, ''))),
+      'B'
+    ) ||
+
+    -- 'C' weight (medium): Publisher and Series
+    setweight(
+      to_tsvector('english', remove_diacritics(COALESCE(NEW.publication_info->>'b', ''))),
+      'C'
+    ) ||
+    setweight(
+      to_tsvector('english', remove_diacritics(COALESCE(NEW.series_statement->>'a', ''))),
+      'C'
+    ) ||
+
+    -- 'D' weight (low): Summary
+    setweight(
+      to_tsvector('english', remove_diacritics(COALESCE(NEW.summary, ''))),
+      'D'
+    );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create a function to normalize search queries (remove diacritics)
+-- This will be used in the application code when performing searches
+CREATE OR REPLACE FUNCTION normalize_search_query(query TEXT)
+RETURNS TEXT AS $$
+BEGIN
+  RETURN remove_diacritics(query);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Rebuild search_vector for all existing records with the new diacritic-insensitive indexing
+UPDATE marc_records SET updated_at = NOW();
+
+-- Add helpful comment
+COMMENT ON FUNCTION update_marc_search_vector() IS
+  'Updates search_vector with weighted, diacritic-insensitive indexing: A=title, B=author+subjects, C=publisher+series, D=summary. Searching for "Zizek" will match "Žižek".';
+
+COMMENT ON FUNCTION remove_diacritics(text) IS
+  'Removes diacritics from text using unaccent extension if available. Used for diacritic-insensitive search.';
+
+COMMENT ON FUNCTION normalize_search_query(text) IS
+  'Normalizes search queries by removing diacritics. Use this on user input before searching to enable diacritic-insensitive search.';
+```
+
+---
+
+## How It Works
+
+### Database Side (Indexing)
+
+When a MARC record is created or updated:
+
+1. **Trigger fires** - `update_marc_search_vector()` is called
+2. **Text extracted** - Pulls title, author, subjects, publisher, series, summary
+3. **Diacritics removed** - `remove_diacritics()` normalizes each field
+   - "Žižek" → "Zizek"
+   - "Café" → "Cafe"
+   - "Müller" → "Muller"
+4. **Search vector created** - Normalized text is indexed with weights
+5. **Saved to database** - `search_vector` column updated
+
+### Application Side (Querying)
+
+When a user searches:
+
+1. **User types** - e.g., "Zizek" (no diacritics)
+2. **Client normalizes** - `normalizeSearchQuery()` removes any diacritics (already none in this case)
+3. **Query sent** - "Zizek" sent to database
+4. **Match found** - Matches indexed "Zizek" (which came from "Žižek")
+5. **Results returned** - Records with "Žižek" are found
+
+### Example Flow
+
+```
+User searches: "Zizek"
+                ↓
+Client normalizes: "Zizek" (already normalized)
+                ↓
+Database compares: "Zizek" (query) == "Zizek" (indexed from "Žižek")
+                ↓
+Match! Returns: Records with "Žižek"
+```
+
+---
+
+## Testing the Migration
+
+### Step 1: Run Diagnostic Tests
+
+Run the test script I created:
+
+```bash
+# In Supabase SQL Editor, run:
+/home/user/ILS/test-diacritic-search.sql
+```
+
+This will check:
+- ✅ Is `unaccent` extension installed?
+- ✅ Do the functions exist?
+- ✅ Does `remove_diacritics()` work correctly?
+- ✅ Are search vectors populated?
+- ✅ Does actual search work?
+
+### Step 2: Manual Test
+
+1. **Create a test record** (if you don't have one with diacritics):
+   ```sql
+   INSERT INTO marc_records (
+     title_statement,
+     main_entry_personal_name,
+     material_type,
+     status,
+     visibility
+   ) VALUES (
+     '{"a": "Less Than Nothing"}'::jsonb,
+     '{"a": "Žižek, Slavoj"}'::jsonb,
+     'book',
+     'active',
+     'public'
+   );
+   ```
+
+2. **Search for it without diacritics**:
+   - Go to your catalog search page
+   - Type "Zizek" (no special characters)
+   - You should see results for "Žižek"
+
+### Step 3: Verify in Database
+
+```sql
+-- This should return records with "Žižek"
+SELECT
+  title_statement->>'a' as title,
+  main_entry_personal_name->>'a' as author
+FROM marc_records
+WHERE search_vector @@ websearch_to_tsquery('english', 'Zizek');
+```
+
+---
+
+## Troubleshooting
+
+### Problem: Tests show unaccent extension is not installed
+
+**Solution:**
+```sql
+CREATE EXTENSION IF NOT EXISTS unaccent;
+```
+
+If you get permission error, contact your Supabase support or database admin.
+
+### Problem: Search vectors are not populated
+
+**Solution:**
+```sql
+-- Rebuild all search vectors
+UPDATE marc_records SET updated_at = NOW();
+```
+
+This triggers the `update_marc_search_vector()` function for all records.
+
+### Problem: Search still doesn't work
+
+**Checklist:**
+1. Did you run the migration? Check with diagnostic tests.
+2. Did you rebuild search vectors? Run the UPDATE command above.
+3. Is the client-side normalization working? Check browser console.
+4. Do you have records with diacritics to test? Try the test record insert.
+
+### Problem: Migration fails with syntax error
+
+**Possible causes:**
+- PostgreSQL version too old (need 9.6+)
+- Supabase restrictions on extensions
+- Missing trigger or table
+
+**Solution:** Run diagnostic tests to identify specific issue.
+
+---
+
+## Rollback (If Needed)
+
+To undo this migration:
+
+```sql
+-- Revert to old search vector function (without diacritic removal)
+CREATE OR REPLACE FUNCTION update_marc_search_vector()
+RETURNS TRIGGER AS $$
+DECLARE
+  subject_text TEXT := '';
+BEGIN
+  IF NEW.subject_topical IS NOT NULL THEN
+    SELECT string_agg(elem->>'a', ' ')
+    INTO subject_text
+    FROM unnest(NEW.subject_topical) AS elem
+    WHERE elem->>'a' IS NOT NULL;
+  END IF;
+
+  NEW.search_vector :=
+    setweight(to_tsvector('english', COALESCE(NEW.title_statement->>'a', '')), 'A') ||
+    setweight(to_tsvector('english', COALESCE(NEW.main_entry_personal_name->>'a', '')), 'B') ||
+    setweight(to_tsvector('english', COALESCE(subject_text, '')), 'B') ||
+    setweight(to_tsvector('english', COALESCE(NEW.publication_info->>'b', '')), 'C') ||
+    setweight(to_tsvector('english', COALESCE(NEW.series_statement->>'a', '')), 'C') ||
+    setweight(to_tsvector('english', COALESCE(NEW.summary, '')), 'D');
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Rebuild search vectors
+UPDATE marc_records SET updated_at = NOW();
+
+-- Optionally drop the functions
+DROP FUNCTION IF EXISTS remove_diacritics(text);
+DROP FUNCTION IF EXISTS normalize_search_query(text);
+```
+
+---
+
+## Performance Impact
+
+**Indexing:** Minimal - `remove_diacritics()` is fast and called only on INSERT/UPDATE
+**Searching:** None - Search performance remains the same
+**Storage:** None - Search vectors are the same size
+
+---
+
+## Examples of Characters Handled
+
+| Original | Normalized | Works? |
+|----------|-----------|---------|
+| Žižek | Zizek | ✅ |
+| Café | Cafe | ✅ |
+| Müller | Muller | ✅ |
+| José | Jose | ✅ |
+| Björk | Bjork | ✅ |
+| Čapek | Capek | ✅ |
+| São Paulo | Sao Paulo | ✅ |
+| Łódź | Lodz | ✅ |
+| Tōkyō | Tokyo | ✅ |
+
+---
+
+## Additional Notes
+
+- The client-side normalization is already implemented in `/src/lib/utils/text-normalize.ts`
+- The application already calls `normalizeSearchQuery()` in search pages
+- This migration makes the database match the client-side behavior
+- Both simple and advanced search are supported
+- Works with all search fields (title, author, subject, etc.)
+
+---
+
+## Questions?
+
+If you have issues:
+1. Run the diagnostic test script first
+2. Check the troubleshooting section above
+3. Review Supabase logs for errors
+4. Check that your PostgreSQL version supports `unaccent` extension
+
+---
+
+**Next Steps:** Run the diagnostic test to see if the migration is already applied!

--- a/test-diacritic-search.sql
+++ b/test-diacritic-search.sql
@@ -1,0 +1,196 @@
+-- Diagnostic Test Script for Diacritic-Insensitive Search
+-- Run this in Supabase SQL Editor to check if the migration was applied correctly
+-- Created: 2026-01-10
+
+-- ==============================================================================
+-- TEST 1: Check if unaccent extension is installed
+-- ==============================================================================
+SELECT
+  'TEST 1: unaccent extension' as test_name,
+  CASE
+    WHEN COUNT(*) > 0 THEN '✅ PASS - unaccent extension is installed'
+    ELSE '❌ FAIL - unaccent extension is NOT installed'
+  END as result
+FROM pg_extension
+WHERE extname = 'unaccent';
+
+-- ==============================================================================
+-- TEST 2: Check if remove_diacritics() function exists
+-- ==============================================================================
+SELECT
+  'TEST 2: remove_diacritics() function' as test_name,
+  CASE
+    WHEN COUNT(*) > 0 THEN '✅ PASS - remove_diacritics() function exists'
+    ELSE '❌ FAIL - remove_diacritics() function does NOT exist'
+  END as result
+FROM pg_proc
+WHERE proname = 'remove_diacritics';
+
+-- ==============================================================================
+-- TEST 3: Check if normalize_search_query() function exists
+-- ==============================================================================
+SELECT
+  'TEST 3: normalize_search_query() function' as test_name,
+  CASE
+    WHEN COUNT(*) > 0 THEN '✅ PASS - normalize_search_query() function exists'
+    ELSE '❌ FAIL - normalize_search_query() function does NOT exist'
+  END as result
+FROM pg_proc
+WHERE proname = 'normalize_search_query';
+
+-- ==============================================================================
+-- TEST 4: Check if update_marc_search_vector() trigger function exists
+-- ==============================================================================
+SELECT
+  'TEST 4: update_marc_search_vector() trigger' as test_name,
+  CASE
+    WHEN COUNT(*) > 0 THEN '✅ PASS - update_marc_search_vector() trigger function exists'
+    ELSE '❌ FAIL - update_marc_search_vector() trigger function does NOT exist'
+  END as result
+FROM pg_proc
+WHERE proname = 'update_marc_search_vector';
+
+-- ==============================================================================
+-- TEST 5: Test remove_diacritics() function with sample data
+-- ==============================================================================
+SELECT
+  'TEST 5: remove_diacritics() functionality' as test_name,
+  input,
+  remove_diacritics(input) as output,
+  CASE
+    WHEN remove_diacritics(input) = expected THEN '✅ PASS'
+    ELSE '❌ FAIL - Expected: ' || expected
+  END as result
+FROM (
+  VALUES
+    ('Žižek', 'Zizek'),
+    ('Café', 'Cafe'),
+    ('Müller', 'Muller'),
+    ('José', 'Jose'),
+    ('Björk', 'Bjork'),
+    ('Čapek', 'Capek')
+) AS test_data(input, expected);
+
+-- ==============================================================================
+-- TEST 6: Check if search_vector includes diacritic removal
+-- ==============================================================================
+-- This checks if the trigger function definition includes remove_diacritics
+SELECT
+  'TEST 6: Search vector trigger includes diacritic removal' as test_name,
+  CASE
+    WHEN pg_get_functiondef(oid) LIKE '%remove_diacritics%'
+    THEN '✅ PASS - Trigger uses remove_diacritics()'
+    ELSE '❌ FAIL - Trigger does NOT use remove_diacritics()'
+  END as result
+FROM pg_proc
+WHERE proname = 'update_marc_search_vector'
+LIMIT 1;
+
+-- ==============================================================================
+-- TEST 7: Check if search_vector is populated for existing records
+-- ==============================================================================
+SELECT
+  'TEST 7: Search vectors are populated' as test_name,
+  COUNT(*) as total_records,
+  COUNT(search_vector) as records_with_search_vector,
+  CASE
+    WHEN COUNT(*) = COUNT(search_vector) THEN '✅ PASS - All records have search_vector'
+    WHEN COUNT(search_vector) > 0 THEN '⚠️ PARTIAL - Some records missing search_vector'
+    ELSE '❌ FAIL - No records have search_vector'
+  END as result
+FROM marc_records;
+
+-- ==============================================================================
+-- TEST 8: Test actual search functionality
+-- ==============================================================================
+-- This tests if searching for "Zizek" finds records containing "Žižek"
+-- First, let's see if there are any records with diacritics in the title or author
+
+SELECT
+  'TEST 8: Sample records with diacritics' as test_name,
+  id,
+  title_statement->>'a' as title,
+  main_entry_personal_name->>'a' as author,
+  '(Check if these contain diacritics)' as note
+FROM marc_records
+WHERE
+  (title_statement->>'a') ~ '[À-ž]' OR
+  (main_entry_personal_name->>'a') ~ '[À-ž]'
+LIMIT 5;
+
+-- ==============================================================================
+-- TEST 9: Test normalized search (simulating what the app does)
+-- ==============================================================================
+-- Search for "Zizek" (no diacritics) using full-text search
+-- This should match "Žižek" if the migration is working
+
+SELECT
+  'TEST 9: Search test - "Zizek" should match "Žižek"' as test_name,
+  COUNT(*) as matching_records,
+  CASE
+    WHEN COUNT(*) > 0 THEN '✅ Possible PASS - Found records (check if they contain Žižek)'
+    ELSE '⚠️ No results - Either no Žižek records exist, or search is not working'
+  END as result
+FROM marc_records
+WHERE search_vector @@ websearch_to_tsquery('english', 'Zizek');
+
+-- ==============================================================================
+-- TEST 10: Show function definitions for manual inspection
+-- ==============================================================================
+SELECT
+  'TEST 10: remove_diacritics() function definition' as test_name,
+  pg_get_functiondef(oid) as function_definition
+FROM pg_proc
+WHERE proname = 'remove_diacritics'
+LIMIT 1;
+
+-- ==============================================================================
+-- SUMMARY
+-- ==============================================================================
+SELECT
+  '═══════════════════════════════════════════════════════════════' as divider,
+  'DIAGNOSTIC SUMMARY' as title;
+
+SELECT
+  '1. If all tests pass (✅), the migration is correctly applied.' as interpretation
+UNION ALL
+SELECT
+  '2. If TEST 1 or 2 fails (❌), run the migration script.' as interpretation
+UNION ALL
+SELECT
+  '3. If TEST 5 fails, the unaccent extension may not be working.' as interpretation
+UNION ALL
+SELECT
+  '4. If TEST 7 shows partial results, run: UPDATE marc_records SET updated_at = NOW();' as interpretation
+UNION ALL
+SELECT
+  '5. If TEST 9 shows no results, check if you have records with "Žižek" in your database.' as interpretation;
+
+-- ==============================================================================
+-- TROUBLESHOOTING: Create a test record with diacritics
+-- ==============================================================================
+-- Uncomment and run this if you want to create a test record to verify search
+
+/*
+INSERT INTO marc_records (
+  title_statement,
+  main_entry_personal_name,
+  material_type,
+  status,
+  visibility
+) VALUES (
+  '{"a": "Less Than Nothing: Hegel and the Shadow of Dialectical Materialism"}'::jsonb,
+  '{"a": "Žižek, Slavoj"}'::jsonb,
+  'book',
+  'active',
+  'public'
+);
+
+-- After inserting, search for "Zizek" (no diacritics) and it should find this record
+SELECT
+  title_statement->>'a' as title,
+  main_entry_personal_name->>'a' as author
+FROM marc_records
+WHERE search_vector @@ websearch_to_tsquery('english', 'Zizek')
+  AND main_entry_personal_name->>'a' LIKE '%Žižek%';
+*/


### PR DESCRIPTION
Problem: Searching for "Zizek" doesn't return results for "Žižek"

Solution: Created comprehensive diagnostic and documentation suite to verify and fix the diacritic-insensitive search feature.

Files added:
- test-diacritic-search.sql: 10-test diagnostic suite to verify migration status
- MIGRATION_024_REFERENCE.md: Complete documentation with examples and troubleshooting
- DIACRITIC_SEARCH_FIX.md: Quick start guide for applying the fix

The migration (024_diacritic_insensitive_search.sql) already exists in the codebase and client-side normalization is implemented. These files help verify if the database migration has been applied and guide users through applying it if needed.

Features:
- Comprehensive diagnostic tests for all migration components
- Step-by-step troubleshooting guide
- Example test cases and SQL queries
- Clear documentation of how the feature works
- Rollback instructions if needed