### PR TITLE
Add overlay/update support to Bulk ISBN Import

### DIFF
--- a/src/routes/(admin)/admin/+layout.svelte
+++ b/src/routes/(admin)/admin/+layout.svelte
@@ -27,7 +27,7 @@
 				<li><a href="/admin/cataloging" onclick={() => mobileMenuOpen = false}>Catalog Records</a></li>
 				<li><a href="/admin/cataloging/new" onclick={() => mobileMenuOpen = false}>New MARC Record</a></li>
 				<li><a href="/admin/cataloging/isbn-lookup" onclick={() => mobileMenuOpen = false}>ISBN Lookup</a></li>
-				<li><a href="/admin/cataloging/bulk-isbn" onclick={() => mobileMenuOpen = false}>Bulk ISBN Upload</a></li>
+				<li><a href="/admin/cataloging/bulk-isbn" onclick={() => mobileMenuOpen = false}>Bulk ISBN Import/Update</a></li>
 				<li><a href="/admin/cataloging/upload" onclick={() => mobileMenuOpen = false}>MARC File Upload</a></li>
 				<li><a href="/admin/cataloging/authorities" onclick={() => mobileMenuOpen = false}>Authorities</a></li>
 				<li><a href="/admin/serials" onclick={() => mobileMenuOpen = false}>Serials Management</a></li>


### PR DESCRIPTION
- Update bulk-isbn page to check for existing records by ISBN
- UPDATE existing records instead of failing with duplicate error
- INSERT new records only if ISBN doesn't exist
- Add status badges showing "NEW" vs "UPDATED" vs "ERROR"
- Show import summary with counts (inserted/updated/errors)
- Disable checkboxes for already-imported records
- Update page title and menu to reflect import/update functionality
- Preserve holdings and relationships when updating existing records
- Auto-create holdings only for newly inserted records

This enables safe record reimporting using ISBN lists without losing existing holdings, checkouts, or relationships.