### PR TITLE
Fix JSONB array handling in search vector function

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -99,9 +99,9 @@ BEGIN
     setweight(to_tsvector('english', COALESCE(NEW.title_statement->>'a', '')), 'A') ||
     setweight(to_tsvector('english', COALESCE(NEW.title_statement->>'b', '')), 'A') ||
 
-    -- Variant titles (weight A)
+    -- Variant titles (weight A) - JSONB[] array
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'title', ' ') FROM jsonb_array_elements(COALESCE(NEW.varying_form_title, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'title', ' ') FROM unnest(COALESCE(NEW.varying_form_title, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'A') ||
 
@@ -109,17 +109,17 @@ BEGIN
     setweight(to_tsvector('english', COALESCE(NEW.main_entry_personal_name->>'a', '')), 'B') ||
     setweight(to_tsvector('english', COALESCE(NEW.main_entry_corporate_name->>'a', '')), 'B') ||
 
-    -- Subjects (weight B)
+    -- Subjects (weight B) - JSONB[] arrays
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'a', ' ') FROM jsonb_array_elements(COALESCE(NEW.subject_topical, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'a', ' ') FROM unnest(COALESCE(NEW.subject_topical, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B') ||
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'a', ' ') FROM jsonb_array_elements(COALESCE(NEW.subject_geographic, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'a', ' ') FROM unnest(COALESCE(NEW.subject_geographic, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B') ||
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'a', ' ') FROM jsonb_array_elements(COALESCE(NEW.genre_form_term, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'a', ' ') FROM unnest(COALESCE(NEW.genre_form_term, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B') ||
 
@@ -137,7 +137,7 @@ BEGIN
     setweight(to_tsvector('simple', COALESCE(NEW.isbn, '')), 'B') ||
     setweight(to_tsvector('simple', COALESCE(NEW.issn, '')), 'B') ||
     setweight(to_tsvector('simple', COALESCE(
-      (SELECT string_agg(elem->>'value', ' ') FROM jsonb_array_elements(COALESCE(NEW.other_standard_identifier, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'value', ' ') FROM unnest(COALESCE(NEW.other_standard_identifier, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B');
 

--- a/migrations/022_additional_marc_fields.sql
+++ b/migrations/022_additional_marc_fields.sql
@@ -41,9 +41,9 @@ BEGIN
     setweight(to_tsvector('english', COALESCE(NEW.title_statement->>'a', '')), 'A') ||
     setweight(to_tsvector('english', COALESCE(NEW.title_statement->>'b', '')), 'A') ||
 
-    -- Variant titles (weight A)
+    -- Variant titles (weight A) - JSONB[] array
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'title', ' ') FROM jsonb_array_elements(COALESCE(NEW.varying_form_title, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'title', ' ') FROM unnest(COALESCE(NEW.varying_form_title, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'A') ||
 
@@ -51,17 +51,17 @@ BEGIN
     setweight(to_tsvector('english', COALESCE(NEW.main_entry_personal_name->>'a', '')), 'B') ||
     setweight(to_tsvector('english', COALESCE(NEW.main_entry_corporate_name->>'a', '')), 'B') ||
 
-    -- Subjects (weight B)
+    -- Subjects (weight B) - JSONB[] arrays
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'a', ' ') FROM jsonb_array_elements(COALESCE(NEW.subject_topical, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'a', ' ') FROM unnest(COALESCE(NEW.subject_topical, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B') ||
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'a', ' ') FROM jsonb_array_elements(COALESCE(NEW.subject_geographic, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'a', ' ') FROM unnest(COALESCE(NEW.subject_geographic, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B') ||
     setweight(to_tsvector('english', COALESCE(
-      (SELECT string_agg(elem->>'a', ' ') FROM jsonb_array_elements(COALESCE(NEW.genre_form_term, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'a', ' ') FROM unnest(COALESCE(NEW.genre_form_term, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B') ||
 
@@ -79,7 +79,7 @@ BEGIN
     setweight(to_tsvector('simple', COALESCE(NEW.isbn, '')), 'B') ||
     setweight(to_tsvector('simple', COALESCE(NEW.issn, '')), 'B') ||
     setweight(to_tsvector('simple', COALESCE(
-      (SELECT string_agg(elem->>'value', ' ') FROM jsonb_array_elements(COALESCE(NEW.other_standard_identifier, '[]'::jsonb)) AS elem),
+      (SELECT string_agg(elem->>'value', ' ') FROM unnest(COALESCE(NEW.other_standard_identifier, ARRAY[]::jsonb[])) AS elem),
       ''
     )), 'B');
 


### PR DESCRIPTION
- Change from jsonb_array_elements() to unnest() for JSONB[] columns
- Fix COALESCE to use ARRAY[]::jsonb[] instead of '[]'::jsonb
- Resolves "COALESCE types jsonb[] and jsonb cannot be matched" error

The issue was that JSONB[] (PostgreSQL array type) requires unnest(), while jsonb_array_elements() is for JSONB values containing JSON arrays.

Affected columns:
- varying_form_title JSONB[]
- subject_topical JSONB[]
- subject_geographic JSONB[]
- genre_form_term JSONB[]
- other_standard_identifier JSONB[]