### PR TITLE
Fix critical import and lookup issues

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -18,7 +18,7 @@ CREATE TABLE marc_records (
   leader VARCHAR(24),
   control_number VARCHAR(50) UNIQUE, -- 001
   control_number_identifier VARCHAR(100), -- 003
-  date_entered VARCHAR(8), -- 008
+  date_entered VARCHAR(40), -- 008 (40-character fixed field)
 
   -- Standard identifiers
   isbn VARCHAR(20), -- 020

--- a/migrations/023_fix_date_entered_length.sql
+++ b/migrations/023_fix_date_entered_length.sql
@@ -1,0 +1,10 @@
+-- Migration 023: Fix date_entered field length
+-- MARC 008 fields are 40 characters, not 8
+-- This fixes "value too long for type character varying(8)" errors during import
+
+-- Alter the column to accommodate full MARC 008 data
+ALTER TABLE marc_records
+  ALTER COLUMN date_entered TYPE VARCHAR(40);
+
+-- Add comment to document the field
+COMMENT ON COLUMN marc_records.date_entered IS 'MARC 008 field - 40-character fixed field with coded information';

--- a/src/routes/(admin)/admin/cataloging/bulk-isbn/+page.svelte
+++ b/src/routes/(admin)/admin/cataloging/bulk-isbn/+page.svelte
@@ -159,14 +159,14 @@
 			}];
 
 			try {
-				// Try OpenLibrary first
-				let bookData = await tryOpenLibrary(isbn);
-				let source = 'OpenLibrary';
+				// Try Library of Congress first (more complete MARC data)
+				let bookData = await tryLibraryOfCongress(isbn);
+				let source = 'Library of Congress';
 
-				// Fallback to LoC if OpenLibrary didn't find it
+				// Fallback to OpenLibrary if LoC didn't find it
 				if (!bookData) {
-					bookData = await tryLibraryOfCongress(isbn);
-					source = 'Library of Congress';
+					bookData = await tryOpenLibrary(isbn);
+					source = 'OpenLibrary';
 				}
 
 				// Update the result

--- a/src/routes/(admin)/admin/cataloging/isbn-lookup/+page.svelte
+++ b/src/routes/(admin)/admin/cataloging/isbn-lookup/+page.svelte
@@ -80,7 +80,7 @@
 	 * Free API - no authentication required
 	 */
 	async function tryOCLCClassify(cleanISBN: string) {
-		const url = `http://classify.oclc.org/classify2/Classify?isbn=${cleanISBN}&summary=true`;
+		const url = `https://classify.oclc.org/classify2/Classify?isbn=${cleanISBN}&summary=true`;
 
 		const response = await fetch(url);
 		const xmlText = await response.text();


### PR DESCRIPTION
- Fix MARCXML import error: date_entered VARCHAR(8) → VARCHAR(40) MARC 008 fields are 40 characters, not 8 Resolves "value too long for type character varying(8)" errors

- Fix bulk ISBN lookup to prioritize Library of Congress LoC provides richer MARC data (LC/Dewey call numbers, editions, etc.) Falls back to OpenLibrary if LoC doesn't have the record

- Fix single ISBN OCLC WorldCat CORS error Changed http:// to https:// to prevent mixed content blocking

Migration 023 must be applied in Supabase SQL Editor