### PR TITLE
Proxy LoC ISBN lookups for bulk import

### DIFF
--- a/src/routes/(admin)/admin/cataloging/bulk-isbn/+page.svelte
+++ b/src/routes/(admin)/admin/cataloging/bulk-isbn/+page.svelte
@@ -118,11 +118,11 @@
 
 	async function tryLibraryOfCongress(cleanISBN: string) {
 		try {
-			const query = encodeURIComponent(`bath.isbn=${cleanISBN}`);
-			const url = `https://lx2.loc.gov:210/lcdb?operation=searchRetrieve&version=1.1&query=${query}&maximumRecords=1&recordSchema=marcxml`;
-
-			// Reduced timeout from 10s to 5s for faster fallback
+			const url = `/api/isbn/loc?isbn=${cleanISBN}`;
 			const response = await fetchWithTimeout(url, 5000);
+			if (!response.ok) {
+				throw new Error(`LoC proxy failed with status ${response.status}`);
+			}
 			const xmlText = await response.text();
 
 			if (xmlText.includes('<numberOfRecords>0</numberOfRecords>')) {

--- a/src/routes/api/isbn/loc/+server.ts
+++ b/src/routes/api/isbn/loc/+server.ts
@@ -1,0 +1,43 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+async function fetchWithTimeout(url: string, timeout = 8000) {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+	try {
+		const response = await fetch(url, { signal: controller.signal });
+		clearTimeout(timeoutId);
+		return response;
+	} catch (err) {
+		clearTimeout(timeoutId);
+		throw err;
+	}
+}
+
+export const GET: RequestHandler = async ({ url }) => {
+	const isbnParam = url.searchParams.get('isbn')?.trim() || '';
+	const cleanISBN = isbnParam.replace(/[^0-9X]/gi, '');
+
+	if (!cleanISBN) {
+		throw error(400, 'ISBN is required');
+	}
+
+	const query = encodeURIComponent(`bath.isbn=${cleanISBN}`);
+	const locUrl = `https://lx2.loc.gov:210/lcdb?operation=searchRetrieve&version=1.1&query=${query}&maximumRecords=1&recordSchema=marcxml`;
+
+	try {
+		const response = await fetchWithTimeout(locUrl, 8000);
+		if (!response.ok) {
+			throw error(502, `LoC API returned ${response.status}`);
+		}
+		const xmlText = await response.text();
+		return new Response(xmlText, {
+			headers: {
+				'content-type': 'text/xml; charset=utf-8'
+			}
+		});
+	} catch (err: any) {
+		throw error(502, err?.message || 'LoC API request failed');
+	}
+};


### PR DESCRIPTION
### Motivation
- Bulk ISBN import was making client-side requests directly to the Library of Congress API which can fail (CORS, network) and prevented LoC MARC fields (call numbers, subject headings) from being appended reliably.

### Description
- Add a server-side proxy endpoint at `src/routes/api/isbn/loc/+server.ts` that queries the LoC SRU endpoint, validates `isbn`, and returns MARCXML with timeout and error handling using `fetchWithTimeout`.
- Update the bulk ISBN UI `src/routes/(admin)/admin/cataloging/bulk-isbn/+page.svelte` to call the new proxy (`/api/isbn/loc?isbn=...`) instead of calling the LoC host directly and to handle non-OK proxy responses.
- Preserve the previous strategy of trying OpenLibrary first and supplementing with LoC data when available to restore call numbers/subjects merging into imported MARC data.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a8f33e8483308380a7cdd101d090)