### PR TITLE
Improve LoC and OCLC ISBN proxy resiliency

### DIFF
--- a/BIBLIOGRAPHIC_APIS.md
+++ b/BIBLIOGRAPHIC_APIS.md
@@ -56,8 +56,13 @@ GET https://covers.openlibrary.org/b/isbn/{isbn}-L.jpg
 
 **API Endpoints Used:**
 ```
-GET https://lx2.loc.gov:210/lcdb?operation=searchRetrieve&version=1.1&query=bath.isbn={isbn}&maximumRecords=1&recordSchema=marcxml
+GET https://lx2.loc.gov:210/LCDB?operation=searchRetrieve&version=1.1&query=bath.isbn={isbn}&maximumRecords=1&recordSchema=marcxml
+GET https://www.loc.gov/sru/?operation=searchRetrieve&version=1.1&query=bath.isbn={isbn}&maximumRecords=1&recordSchema=marcxml
 ```
+
+**Configurable Options:**
+- `LOC_SRU_BASE_URL` (primary SRU endpoint, defaults to `https://lx2.loc.gov:210/LCDB`)
+- `LOC_SRU_FALLBACK_BASE_URL` (fallback SRU endpoint, defaults to `https://www.loc.gov/sru/`)
 
 **Rate Limits**: None specified, reasonable use expected  
 **Reliability**: Very high (government service)  
@@ -97,6 +102,9 @@ GET https://classify.oclc.org/classify2/Classify?isbn={isbn}&summary=true
 **Rate Limits**: Fair use (no published limits)  
 **Reliability**: Very high  
 **Coverage**: Excellent (largest bibliographic database in the world)
+
+**Configurable Options:**
+- `OCLC_CLASSIFY_WSKEY` (optional OCLC Classify WSKey if your tenant requires it)
 
 ---
 

--- a/src/routes/api/isbn/loc/+server.ts
+++ b/src/routes/api/isbn/loc/+server.ts
@@ -39,27 +39,51 @@ export const GET: RequestHandler = async ({ url }) => {
 		throw error(400, 'ISBN is required');
 	}
 
-	const baseUrl = env.LOC_SRU_BASE_URL || 'https://lx2.loc.gov:210/lcdb';
+	const baseUrl = env.LOC_SRU_BASE_URL || 'https://lx2.loc.gov:210/LCDB';
+	const fallbackBaseUrl = env.LOC_SRU_FALLBACK_BASE_URL || 'https://www.loc.gov/sru/';
 	const userAgent = env.BIBLIOGRAPHIC_PROXY_USER_AGENT || 'ILS ISBN Lookup';
-	const query = encodeURIComponent(`bath.isbn=${cleanISBN}`);
-	const locUrl = `${baseUrl}?operation=searchRetrieve&version=1.1&query=${query}&maximumRecords=1&recordSchema=marcxml`;
+	const query = `bath.isbn=${cleanISBN}`;
+	const buildLocUrl = (rootUrl: string) => {
+		const locUrl = new URL(rootUrl);
+		locUrl.searchParams.set('operation', 'searchRetrieve');
+		locUrl.searchParams.set('version', '1.1');
+		locUrl.searchParams.set('query', query);
+		locUrl.searchParams.set('maximumRecords', '1');
+		locUrl.searchParams.set('recordSchema', 'marcxml');
+		return locUrl.toString();
+	};
+	const locUrls = [buildLocUrl(baseUrl)];
+	const fallbackUrl = buildLocUrl(fallbackBaseUrl);
+	if (fallbackUrl !== locUrls[0]) {
+		locUrls.push(fallbackUrl);
+	}
 
 	try {
-		const response = await fetchWithRetry(locUrl, 8000, {
-			headers: {
-				'User-Agent': userAgent,
-				'Accept': 'text/xml'
+		let lastError = 'LoC API request failed';
+		for (const locUrl of locUrls) {
+			try {
+				const response = await fetchWithRetry(locUrl, 8000, {
+					headers: {
+						'User-Agent': userAgent,
+						'Accept': 'text/xml, application/xml'
+					}
+				});
+				if (response.ok) {
+					const xmlText = await response.text();
+					return new Response(xmlText, {
+						headers: {
+							'content-type': 'text/xml; charset=utf-8'
+						}
+					});
+				}
+				const errorBody = await response.text().catch(() => '');
+				const details = errorBody ? `: ${errorBody.slice(0, 200)}` : '';
+				lastError = `LoC API returned ${response.status}${details}`;
+			} catch (err: any) {
+				lastError = err?.message || lastError;
 			}
-		});
-		if (!response.ok) {
-			throw error(502, `LoC API returned ${response.status}`);
 		}
-		const xmlText = await response.text();
-		return new Response(xmlText, {
-			headers: {
-				'content-type': 'text/xml; charset=utf-8'
-			}
-		});
+		throw error(502, lastError);
 	} catch (err: any) {
 		throw error(502, err?.message || 'LoC API request failed');
 	}


### PR DESCRIPTION
### Motivation
- ISBN lookups against OCLC Classify and Library of Congress SRU were brittle and returning opaque errors or failing when the primary LoC endpoint was unavailable. 
- The intent is to make those proxies more resilient, configurable, and easier to debug by surfacing upstream error details and supporting alternate endpoints/credentials.

### Description
- Added optional `OCLC_CLASSIFY_WSKEY` support and switched the OCLC proxy to build the request with `URL` so the WSKey (when provided) is passed as a `wskey` query parameter, and returned error responses now include up to 200 characters of upstream body text for diagnostics (`src/routes/api/isbn/oclc/+server.ts`).
- Standardized the default LoC SRU base URL to `https://lx2.loc.gov:210/LCDB`, added `LOC_SRU_FALLBACK_BASE_URL` with a default of `https://www.loc.gov/sru/`, and implemented trying the primary SRU endpoint then the fallback, collecting and returning the last error for clearer failure messages (`src/routes/api/isbn/loc/+server.ts`).
- Tightened request `Accept` headers for LoC, added robust URL construction using `URL`, and preserved existing timeout/retry logic via `fetchWithRetry` in both proxies.
- Documented the new endpoints and environment configuration options (`LOC_SRU_BASE_URL`, `LOC_SRU_FALLBACK_BASE_URL`, `OCLC_CLASSIFY_WSKEY`) in `BIBLIOGRAPHIC_APIS.md`.

### Testing
- No automated tests were run for these changes.
- Code changes were committed locally and basic static inspection was performed; runtime verification was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ab28daa3c833094293acc894ebcf7)